### PR TITLE
Return a vector of samples instead of an error

### DIFF
--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -298,7 +298,7 @@ function bundle_samples(
     ts::Vector{T}; 
     kwargs...
 ) where {ModelType<:AbstractModel, SamplerType<:AbstractSampler, T<:AbstractTransition}
-    error("No bundle_samples function defined")
+    return ts
 end
 
 """


### PR DESCRIPTION
The PR makes it such that `bundle_samples` will default to just returning the vector of `AbstractTransition` object when no overload has been defined, so you could theoretically get around having a heavy `MCMCChains` constructor by simply not defining `bundle_samples`.