### PR TITLE
Allow dispatch on chain type

### DIFF
--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -198,6 +198,7 @@ function sample(
     s::SamplerType,
     N::Integer;
     progress::Bool=true,
+    chain_type::Type=Type{Any},
     kwargs...
 ) where {ModelType<:AbstractModel, SamplerType<:AbstractSampler}
     # Perform any necessary setup.
@@ -224,7 +225,11 @@ function sample(
     # Wrap up the sampler, if necessary.
     sample_end!(rng, ℓ, s, N, ts; kwargs...)
 
-    return bundle_samples(rng, ℓ, s, N, ts; kwargs...)
+    if chain_type == Type{Any}
+        return bundle_samples(rng, ℓ, s, N, ts; kwargs...)
+    else
+        return bundle_samples(rng, ℓ, s, N, ts, chain_type; kwargs...)
+    end
 end
 
 """
@@ -299,6 +304,18 @@ function bundle_samples(
     kwargs...
 ) where {ModelType<:AbstractModel, SamplerType<:AbstractSampler, T<:AbstractTransition}
     return ts
+end
+
+function bundle_samples(
+    rng::AbstractRNG, 
+    ℓ::AbstractModel, 
+    s::SamplerType, 
+    N::Integer, 
+    ts::Vector{T},
+    chain_type::Type; 
+    kwargs...
+) where {ModelType<:AbstractModel, SamplerType<:AbstractSampler, T<:AbstractTransition}
+    error("No bundle_samples implementation for type $chain_type")
 end
 
 """


### PR DESCRIPTION
Users can now pass in a keyword argument to `sample` to define the type of the chain they want to receive after sampling. It's the responsibility of package developers to support chain construction for different types. An example of usage might be

```julia
chain1 = sample(model, sampler, 1000; chain_type = NamedTuple)
chain2 = sample(model, sampler, 1000; chain_type = MCMCChains.Chains)
chain3 = sample(model, sampler, 1000; chain_type = Array)
```

If no keyword is specified, this defaults to whatever a package developer sets as the default constructor `bundle_samples`, or it simply returns the vector of `AbstractTransition` if the package developer has not created a catch-all overload of `bundle_samples`.