### PR TITLE
Allow dispatch on chain type (take two)

### DIFF
--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -180,6 +180,7 @@ function sample(
     s::AbstractSampler,
     N::Integer;
     progress::Bool=true,
+    chain_type::Type=Any,
     kwargs...
 )
     # Perform any necessary setup.
@@ -206,7 +207,7 @@ function sample(
     # Wrap up the sampler, if necessary.
     sample_end!(rng, ℓ, s, N, ts; kwargs...)
 
-    return bundle_samples(rng, ℓ, s, N, ts; kwargs...)
+    return bundle_samples(rng, ℓ, s, N, ts, chain_type; kwargs...)
 end
 
 """
@@ -256,17 +257,13 @@ perform any clean-up or finalization.
 """
 function sample_end!(
     rng::AbstractRNG,
-    ℓ::ModelType,
-    s::SamplerType,
+    ℓ::AbstractModel,
+    s::AbstractSampler,
     N::Integer,
-    ts::Vector{TransitionType};
+    ts::Vector{<:AbstractTransition};
     debug::Bool=false,
     kwargs...
-) where {
-    ModelType<:AbstractModel,
-    SamplerType<:AbstractSampler,
-    TransitionType<:AbstractTransition
-}
+)
     # Do nothing.
     debug && @warn "No sample_end! function has been implemented for objects
            of types $(typeof(ℓ)) and $(typeof(s))"
@@ -275,11 +272,12 @@ end
 function bundle_samples(
     rng::AbstractRNG, 
     ℓ::AbstractModel, 
-    s::SamplerType, 
+    s::AbstractSampler, 
     N::Integer, 
-    ts::Vector{T}; 
+    ts::Vector{<:AbstractTransition},
+    chain_type::Type{Any}; 
     kwargs...
-) where {ModelType<:AbstractModel, SamplerType<:AbstractSampler, T<:AbstractTransition}
+)
     return ts
 end
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -52,7 +52,8 @@ function AbstractMCMC.bundle_samples(
     model::MyModel,
     sampler::MySampler,
     N::Integer,
-    transitions::Vector{MyTransition};
+    transitions::Vector{MyTransition},
+    chain_type::Type{Any};
     kwargs...
 )
     n = length(transitions)
@@ -65,6 +66,18 @@ function AbstractMCMC.bundle_samples(
     end
 
     return MyChain(as, bs)
+end
+
+function AbstractMCMC.bundle_samples(
+    rng::AbstractRNG,
+    model::MyModel,
+    sampler::MySampler,
+    N::Integer,
+    transitions::Vector{MyTransition},
+    chain_type::Type{Vector};
+    kwargs...
+)
+    return transitions
 end
 
 AbstractMCMC.chainscat(chains::Union{MyChain,Vector{<:MyChain}}...) = vcat(chains...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,44 +6,55 @@ using Test
 
 include("interface.jl")
 
-@testset "Basic sampling" begin
-    Random.seed!(1234)
-    chain = sample(MyModel(), MySampler(), 10_000; progress = true, sleepy = true)
-
-    # test output type and size
-    @test chain isa MyChain
-    @test length(chain.as) == 10_000
-    @test length(chain.bs) == 10_000
-
-    # test some statistical properties
-    @test mean(chain.as) ≈ 0.5 atol=1e-2
-    @test var(chain.as) ≈ 1 / 12 atol=5e-3
-    @test mean(chain.bs) ≈ 0.0 atol=5e-2
-    @test var(chain.bs) ≈ 1 atol=5e-2
-end
-
-if VERSION ≥ v"1.3"
-    @testset "Parallel sampling" begin
-        println("testing parallel sampling with ", Threads.nthreads(), " thread(s)...")
-
+@testset "AbstractMCMC" begin
+    @testset "Basic sampling" begin
         Random.seed!(1234)
-        chains = psample(MyModel(), MySampler(), 10_000, 1_000)
+        N = 1_000
+        chain = sample(MyModel(), MySampler(), N; progress = true, sleepy = true)
 
         # test output type and size
-        @test chains isa Vector{MyChain}
-        @test length(chains) == 1000
-        @test all(x -> length(x.as) == length(x.bs) == 10_000, chains)
+        @test chain isa MyChain
+        @test length(chain.as) == N
+        @test length(chain.bs) == N
 
         # test some statistical properties
-        @test all(x -> isapprox(mean(x.as), 0.5; atol=1e-2), chains)
-        @test all(x -> isapprox(var(x.as), 1 / 12; atol=5e-3), chains)
-        @test all(x -> isapprox(mean(x.bs), 0; atol=5e-2), chains)
-        @test all(x -> isapprox(var(x.bs), 1; atol=5e-2), chains)
+        @test mean(chain.as) ≈ 0.5 atol=1e-2
+        @test var(chain.as) ≈ 1 / 12 atol=5e-3
+        @test mean(chain.bs) ≈ 0.0 atol=5e-2
+        @test var(chain.bs) ≈ 1 atol=5e-2
+    end
 
-        # test reproducibility
-        Random.seed!(1234)
-        chains2 = psample(MyModel(), MySampler(), 10_000, 1000)
+    if VERSION ≥ v"1.3"
+        @testset "Parallel sampling" begin
+            println("testing parallel sampling with ", Threads.nthreads(), " thread(s)...")
 
-        @test all(((x, y),) -> x.as == y.as && x.bs == y.bs, zip(chains, chains2))
+            Random.seed!(1234)
+            chains = psample(MyModel(), MySampler(), 10_000, 1_000)
+
+            # test output type and size
+            @test chains isa Vector{MyChain}
+            @test length(chains) == 1000
+            @test all(x -> length(x.as) == length(x.bs) == 10_000, chains)
+
+            # test some statistical properties
+            @test all(x -> isapprox(mean(x.as), 0.5; atol=1e-2), chains)
+            @test all(x -> isapprox(var(x.as), 1 / 12; atol=5e-3), chains)
+            @test all(x -> isapprox(mean(x.bs), 0; atol=5e-2), chains)
+            @test all(x -> isapprox(var(x.bs), 1; atol=5e-2), chains)
+
+            # test reproducibility
+            Random.seed!(1234)
+            chains2 = psample(MyModel(), MySampler(), 10_000, 1000)
+
+            @test all(((x, y),) -> x.as == y.as && x.bs == y.bs, zip(chains, chains2))
+        end
+    end
+
+    @testset "Chain constructors" begin
+        chain1 = sample(MyModel(), MySampler(), 100; progress = true, sleepy = true)
+        chain2 = sample(MyModel(), MySampler(), 100; progress = true, sleepy = true, chain_type = Vector)
+
+        @test chain1 isa MyChain
+        @test chain2 isa Vector{MyTransition}
     end
 end


### PR DESCRIPTION
I undid #6 because I missed some comments. I've addressed them here by pulling out some static type constraints and allowing for a single default `bundle_samples` method instead of two.

