### PR TITLE
Change handling of transitions

### DIFF
--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -1,25 +1,10 @@
 module AbstractMCMC
 
-using Random, ProgressMeter
-import Random: GLOBAL_RNG, AbstractRNG, seed!
-import StatsBase: sample
+using ProgressMeter
+import StatsBase
+using StatsBase: sample
 
-export AbstractSampler,
-    AbstractChains,
-    AbstractTransition,
-    AbstractCallback,
-    init_callback,
-    callback,
-    chainscat,
-    transitions_init,
-    transition_type,
-    sample_init!,
-    sample_end!,
-    sample,
-    psample,
-    AbstractModel,
-    AbstractRNG,
-    step!
+using Random: GLOBAL_RNG, AbstractRNG, seed!
 
 """
     AbstractChains
@@ -296,9 +281,9 @@ function transitions_init(
     transition,
     ::AbstractModel,
     ::AbstractSampler,
-        N::Integer;
-        kwargs...
-    )
+    N::Integer;
+    kwargs...
+)
     return Vector{typeof(transition)}(undef, N)
 end
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,13 +1,13 @@
-struct MyModel <: AbstractModel end
+struct MyModel <: AbstractMCMC.AbstractModel end
 
 struct MyTransition
     a::Float64
     b::Float64
 end
 
-struct MySampler <: AbstractSampler end
+struct MySampler <: AbstractMCMC.AbstractSampler end
 
-struct MyChain <: AbstractChains
+struct MyChain <: AbstractMCMC.AbstractChains
     as::Vector{Float64}
     bs::Vector{Float64}
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -35,7 +35,7 @@ function AbstractMCMC.bundle_samples(
     sampler::MySampler,
     N::Integer,
     transitions::Vector{MyTransition},
-    chain_type::Type{Any};
+    chain_type::Type{MyChain};
     kwargs...
 )
     n = length(transitions)
@@ -48,18 +48,6 @@ function AbstractMCMC.bundle_samples(
     end
 
     return MyChain(as, bs)
-end
-
-function AbstractMCMC.bundle_samples(
-    rng::AbstractRNG,
-    model::MyModel,
-    sampler::MySampler,
-    N::Integer,
-    transitions::Vector{MyTransition},
-    chain_type::Type{Vector};
-    kwargs...
-)
-    return transitions
 end
 
 AbstractMCMC.chainscat(chains::Union{MyChain,Vector{<:MyChain}}...) = vcat(chains...)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,13 +1,11 @@
 struct MyModel <: AbstractModel end
 
-struct MyTransition <: AbstractTransition
+struct MyTransition
     a::Float64
     b::Float64
 end
 
 struct MySampler <: AbstractSampler end
-
-AbstractMCMC.transition_type(::MySampler) = MyTransition
 
 struct MyChain <: AbstractChains
     as::Vector{Float64}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using AbstractMCMC
+using AbstractMCMC: sample, psample
 
 using Random
 using Statistics


### PR DESCRIPTION
I've thought a bit more about `transition_type`, and how to improve on what I mentioned in https://github.com/TuringLang/AbstractMCMC.jl/pull/9#discussion_r370753197.

In this PR I propose the following changes:
- Remove `transition_type` and instead just obtain the first transition
- Pass the initial transition to `transitions_init`, whose default implementation just creates a vector for `N` transitions of the type of the initial transition
- Add a function `transitions_save!` to which (among others) the transitions container, the current iteration, and the current transition is passed; the default implementation for vector-type containers just saves the current transition in the container
- Remove `AbstractTransition`
- Do not export anything

The main advantages with this approach are:
- Users/developers do not have to define `transition_type` - as long as their `step!` implementation is type stable it just works
- It seems trivial to, e.g., add a wrapper sampler
  ```julia
  struct StreamingSampler{S<:AbstractSampler,I}
      io::I
      sampler::S
  end

  stream(io, sampler::AbstractSampler) = StreamingSampler(io, sampler)

  AbstractMCMC.sample_init!(rng::AbstractRNG, model::AbstractModel, sampler::StreamingSampler, N::Integer; kwargs...) = sample_init!(rng, model, sampler.sampler, N; kwargs...)
  AbstractMCMC.sample_end!(rng::AbstractRNG, model::AbstractModel, sampler::StreamingSampler, N::Integer, transitions; kwargs...) = sample_end!(rng, model, sampler.sampler, N, transitions; kwargs...)
  AbstractMCMC.bundle_samples!(rng::AbstractRNG, model::AbstractModel, sampler::StreamingSampler, N::Integer, ::Nothing; kwargs...) = nothing

  AbstractMCMC.transitions_init!(transition, ::AbstractModel, sampler::StreamingSampler, ::Integer; kwargs...) = nothing
  AbstractMCMC.transitions_save!(::Nothing, ::Integer, transition, ::AbstractModel, ::StreamingSampler, ::Integer) = write(sampler.io, transition)
  ```
  as suggested in https://github.com/TuringLang/Turing.jl/issues/1053
- One does not have to wrap parameter vectors or named tuples inside of a custom `AbstractTransition` subtype anymore - if `step!` just returns a parameter vector or a named tuple, the default implementation of `sample` will just yield a vector of parameter vectors or named tuples
- It does not seem useful to pollute the namespace by exporting methods such as `sample_init!` or `sample_end!` (which many people do not want to call directly and have to be imported anyway if implemented for specific types). In general, I think in every concrete implementation of AbstractModel/AbstractSampler one just has to decide which methods of AbstractMCMC to export (probably just `sample` and `psample`).