### PR TITLE
Add iterator interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -415,8 +415,8 @@ end
 ##################
 # Iterator tools #
 ##################
-struct Stepper{ModelType<:AbstractModel, SamplerType<:AbstractSampler, K}
-    rng::AbstractRNG
+struct Stepper{A<:AbstractRNG, ModelType<:AbstractModel, SamplerType<:AbstractSampler, K}
+    rng::A
     model::ModelType
     s::SamplerType
     kwargs::K
@@ -460,8 +460,7 @@ function steps!(
     kwargs...
 )
     sample_init!(rng, model, s, 0)
-    iterable = Stepper(rng, model, s, kwargs)
+    return Stepper(rng, model, s, kwargs)
 end
-
 
 end # module AbstractMCMC

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -415,23 +415,20 @@ end
 ##################
 # Iterator tools #
 ##################
-struct Stepper{ModelType<:AbstractModel, SamplerType<:AbstractSampler, T, K}
+struct Stepper{ModelType<:AbstractModel, SamplerType<:AbstractSampler, K}
     rng::AbstractRNG
     model::ModelType
     s::SamplerType
-    t::T
     kwargs::K
 end
 
-function Base.iterate(stp::Stepper, state=(stp.t, 0))
-    t, i = state
-    new_t = step!(stp.rng, stp.model, stp.s, 1, t; stp.kwargs...)
-    
-    return t, (new_t, i+1)
+function Base.iterate(stp::Stepper, state=nothing)
+    t = step!(stp.rng, stp.model, stp.s, 1, state; stp.kwargs...)
+    return t, t
 end
 
 Base.IteratorSize(::Type{<:Stepper}) = Base.IsInfinite()
-Base.eltype(::Type{<:Stepper{<:AbstractModel,<:AbstractSampler,T}}) where T = T
+Base.IteratorEltype(::Type{<:Stepper}) = Base.EltypeUnknown()
 
 """
     steps!([rng::AbstractRNG, ]model::AbstractModel, s::AbstractSampler, kwargs...)
@@ -463,7 +460,7 @@ function steps!(
     kwargs...
 )
     sample_init!(rng, model, s, 0)
-    iterable = Stepper(rng, model, s, step!(rng, model, s, 1, nothing; kwargs...), kwargs)
+    iterable = Stepper(rng, model, s, kwargs)
 end
 
 

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -430,6 +430,9 @@ function Base.iterate(stp::Stepper, state=(stp.t, 0))
     return t, (new_t, i+1)
 end
 
+Base.IteratorSize(::Type{<:Stepper}) = Base.IsInfinite()
+Base.eltype(::Type{<:Stepper{<:AbstractModel,<:AbstractSampler,T}}) where T = T
+
 """
     steps!([rng::AbstractRNG, ]model::AbstractModel, s::AbstractSampler, kwargs...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using AbstractMCMC
-using AbstractMCMC: sample, psample
+using AbstractMCMC: sample, psample, steps!
 
 using Random
 using Statistics
@@ -56,5 +56,25 @@ include("interface.jl")
 
         @test chain1 isa Vector{MyTransition}
         @test chain2 isa MyChain
+    end
+
+    @testset "Iterator sampling" begin
+        Random.seed!(1234)
+        as = []
+        bs = []
+
+        for (count, t) in enumerate(steps!(MyModel(), MySampler()))
+            if count >= 1000
+                break
+            end
+
+            push!(as, t.a)
+            push!(bs, t.b)
+        end
+
+        @test mean(as) ≈ 0.5 atol=1e-2
+        @test var(as) ≈ 1 / 12 atol=5e-3
+        @test mean(bs) ≈ 0.0 atol=5e-2
+        @test var(bs) ≈ 1 atol=5e-2
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,7 +63,9 @@ include("interface.jl")
         as = []
         bs = []
 
-        for (count, t) in enumerate(steps!(MyModel(), MySampler()))
+        iter = steps!(MyModel(), MySampler())
+
+        for (count, t) in enumerate(iter)
             if count >= 1000
                 break
             end
@@ -76,5 +78,9 @@ include("interface.jl")
         @test var(as) ≈ 1 / 12 atol=5e-3
         @test mean(bs) ≈ 0.0 atol=5e-2
         @test var(bs) ≈ 1 atol=5e-2
+
+        println(eltype(iter))
+        @test Base.IteratorSize(iter) == Base.IsInfinite()
+        @test Base.IteratorEltype(iter) == Base.EltypeUnknown()
     end
 end


### PR DESCRIPTION
Allows the use of `steps!`, which returns an iterator that continuously draws samples. Currently it's pretty bare bones, but I'm open to suggestions on what other functionality that could be included.

Usage:

```julia
# Sample until 1000 iterations are hit.
for (total, transition) in enumerate(AbstractMCMC.steps!(MyModel(), MySampler()))
    println(transition)
    
    if total >= 1000
        break
    end
end
```