### PR TITLE
Use ProgressLogging instead of ProgressMeter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/Project.toml
+++ b/Project.toml
@@ -6,18 +6,22 @@ desc = "A lightweight interface for common MCMC methods."
 version = "0.4.0"
 
 [deps]
-ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+ProgressLogging = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-ProgressMeter = "1.2"
+ProgressLogging = "0.1"
 StatsBase = "0.32"
 julia = "1"
 
 [extras]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Statistics", "Test"]
+test = ["Statistics", "Test", "TerminalLoggers"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,14 @@
 using AbstractMCMC
 using AbstractMCMC: sample, psample, steps!
+using TerminalLoggers: TerminalLogger
 
+using Logging: global_logger
 using Random
 using Statistics
 using Test
+
+# install progress logger
+global_logger(TerminalLogger(right_justify=120))
 
 include("interface.jl")
 
@@ -11,17 +16,17 @@ include("interface.jl")
     @testset "Basic sampling" begin
         Random.seed!(1234)
         N = 1_000
-        chain = sample(MyModel(), MySampler(), N; progress = true, sleepy = true)
+        chain = sample(MyModel(), MySampler(), N; sleepy = true)
 
         # test output type and size
         @test chain isa Vector{MyTransition}
         @test length(chain) == N
 
         # test some statistical properties
-        @test mean(x.a for x in chain) ≈ 0.5 atol=1e-2
+        @test mean(x.a for x in chain) ≈ 0.5 atol=6e-2
         @test var(x.a for x in chain) ≈ 1 / 12 atol=5e-3
         @test mean(x.b for x in chain) ≈ 0.0 atol=5e-2
-        @test var(x.b for x in chain) ≈ 1 atol=5e-2
+        @test var(x.b for x in chain) ≈ 1 atol=6e-2
     end
 
     if VERSION ≥ v"1.3"
@@ -51,11 +56,19 @@ include("interface.jl")
     end
 
     @testset "Chain constructors" begin
-        chain1 = sample(MyModel(), MySampler(), 100; progress = true, sleepy = true)
-        chain2 = sample(MyModel(), MySampler(), 100; progress = true, sleepy = true, chain_type = MyChain)
+        chain1 = sample(MyModel(), MySampler(), 100; sleepy = true)
+        chain2 = sample(MyModel(), MySampler(), 100; sleepy = true, chain_type = MyChain)
 
         @test chain1 isa Vector{MyTransition}
         @test chain2 isa MyChain
+    end
+
+    @testset "Suppress output" begin
+        sample(MyModel(), MySampler(), 100; progress = false, sleepy = true)
+
+        if VERSION ≥ v"1.3"
+            psample(MyModel(), MySampler(), 10_000, 1000; progress = false, chain_type = MyChain)
+        end
     end
 
     @testset "Iterator sampling" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,15 @@
 using AbstractMCMC
 using AbstractMCMC: sample, psample, steps!
-using TerminalLoggers: TerminalLogger
+import TerminalLoggers
 
-using Logging: global_logger
+import Logging
 using Random
 using Statistics
 using Test
+using Test: collect_test_logs
 
 # install progress logger
-global_logger(TerminalLogger(right_justify=120))
+Logging.global_logger(TerminalLoggers.TerminalLogger(right_justify=120))
 
 include("interface.jl")
 
@@ -64,10 +65,17 @@ include("interface.jl")
     end
 
     @testset "Suppress output" begin
-        sample(MyModel(), MySampler(), 100; progress = false, sleepy = true)
+        logs, _ = collect_test_logs(; min_level=Logging.LogLevel(-1)) do
+            sample(MyModel(), MySampler(), 100; progress = false, sleepy = true)
+        end
+        @test isempty(logs)
 
         if VERSION ≥ v"1.3"
-            psample(MyModel(), MySampler(), 10_000, 1000; progress = false, chain_type = MyChain)
+            logs, _ = collect_test_logs(; min_level=Logging.LogLevel(-1)) do
+                psample(MyModel(), MySampler(), 10_000, 1000;
+                        progress = false, chain_type = MyChain)
+            end
+            @test isempty(logs)
         end
     end
 


### PR DESCRIPTION
This PR removes `AbstractCallback` and instead allows the user to provide a custom callback function. Moreover, progress logging is separated from callback handling and uses ProgressLogging instead of ProgressMeter.

ProgressLogging uses Julia's logging system to create, update, and display progress bars. It integrates nicely with Juno and can also be used in the terminal with TerminalLoggers. Among others, it is used by JuliaDiffEq and Flux for displaying progress bars. The current implementation does not make use of the updated functionality (e.g., nested progress bars) and API in ProgressLogging 0.1.1 since it is not fully supported yet by, e.g., TerminalLoggers.