### PR TITLE
Display warning message if no known progress logging frontend is loaded

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,11 +10,13 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 ProgressLogging = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 ProgressLogging = "0.1"
+Requires = "1"
 StatsBase = "0.32"
 julia = "1"
 


### PR DESCRIPTION
This PR is a take on https://github.com/TuringLang/AbstractMCMC.jl/issues/18#issuecomment-594759943. I'm not sure yet how reliable this approach detects if one of the known and recommend progress logging frontends is set up, or not.