### PR TITLE
Fix module of progress logger

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 ConsoleProgressMonitor = "88cd18e8-d9cc-4ea6-8889-5259c0d15c8b"

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -20,7 +20,7 @@ macro ifwithprogresslogger(progress, exprs...)
             if $hasprogresslevel($Logging.current_logger())
                 $ProgressLogging.@withprogress $(exprs...)
             else
-                $with_progresslogger($Logging.current_logger()) do
+                $with_progresslogger($Base.@__MODULE__, $Logging.current_logger()) do
                     $ProgressLogging.@withprogress $(exprs...)
                 end
             end
@@ -36,8 +36,7 @@ function hasprogresslevel(logger)
 end
 
 # filter better, e.g., according to group?
-function with_progresslogger(f, logger)
-    _module = @__MODULE__
+function with_progresslogger(f, _module, logger)
     logger1 = LoggingExtras.EarlyFilteredLogger(progresslogger()) do log
         log._module === _module && log.level == ProgressLogging.ProgressLevel
     end


### PR DESCRIPTION
When I updated Turing VI to use `@ifwithprogresslogger` as well I noticed a stupid bug which limits the reuse of the macro in other packages (currently it only works correctly when used inside of AbstractMCMC).