### PR TITLE
Use ConsoleProgressMonitor on Windows

### DIFF
--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -50,7 +50,7 @@ end
 function progresslogger()
     # detect if code is running under IJulia since TerminalLogger does not work with IJulia
     # https://github.com/JuliaLang/IJulia.jl#detecting-that-code-is-running-under-ijulia
-    if isdefined(Main, :IJulia) && Main.IJulia.inited
+    if Sys.iswindows() || (isdefined(Main, :IJulia) && Main.IJulia.inited)
         return ConsoleProgressMonitor.ProgressLogger()
     else
         return TerminalLoggers.TerminalLogger()


### PR DESCRIPTION
Although ConsoleProgressMonitor is considered "more or less dead", it seems to work a bit better on Windows (see https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/450#issuecomment-596313957).