### PR TITLE
Do not implement `step!` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 ConsoleProgressMonitor = "88cd18e8-d9cc-4ea6-8889-5259c0d15c8b"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -78,15 +78,13 @@ When sampling from the `sampler` using [`sample`](@ref), every `step!` call afte
 has access to the previous `transition`. In the first call, `transition` is set to `nothing`.
 """
 function step!(
-    ::Random.AbstractRNG,
+    rng::Random.AbstractRNG,
     model::AbstractModel,
     sampler::AbstractSampler,
-    ::Integer = 1,
-    transition = nothing;
+    N::Integer = 1;
     kwargs...
 )
-    error("function `step!` is not implemented for models of type $(typeof(model)), ",
-        "samplers of type $(typeof(sampler)), and transitions of type $(typeof(transition))")
+    return step!(rng, model, sampler, N, nothing; kwargs...)
 end
 
 """


### PR DESCRIPTION
We really shouldn't have a default implementation of the full argument `step!` function in this package.