### PR TITLE
Check if the number of chains is greater than the number of samples per chain

### DIFF
--- a/src/sample.jl
+++ b/src/sample.jl
@@ -197,6 +197,11 @@ function mcmcsample(
         @warn "Only a single thread available: MCMC chains are not sampled in parallel"
     end
 
+    # Check if the number of chains is larger than the number of samples
+    if nchains > N
+        @warn "Number of chains ($nchains) is greater than number of samples per chain ($N)"
+    end
+
     # Copy the random number generator, model, and sample for each thread
     rngs = [deepcopy(rng) for _ in 1:Threads.nthreads()]
     models = [deepcopy(model) for _ in 1:Threads.nthreads()]
@@ -267,6 +272,11 @@ function mcmcsample(
     # Check if actually multiple processes are used.
     if Distributed.nworkers() == 1
         @warn "Only a single process available: MCMC chains are not sampled in parallel"
+    end
+
+    # Check if the number of chains is larger than the number of samples
+    if nchains > N
+        @warn "Number of chains ($nchains) is greater than number of samples per chain ($N)"
     end
 
     # Create a seed for each chain using the provided random number generator.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,6 +139,11 @@ include("interface.jl")
 
             @test all(((x, y),) -> x.as == y.as && x.bs == y.bs, zip(chains, chains2))
 
+            # Unexpected order of arguments.
+            str = "Number of chains (10) is greater than number of samples per chain (5)"
+            @test_logs (:warn, str) sample(MyModel(), MySampler(), MCMCThreads(), 5, 10;
+                                           chain_type = MyChain)
+
             # Suppress output.
             logs, _ = collect_test_logs(; min_level=Logging.LogLevel(-1)) do
                 sample(MyModel(), MySampler(), MCMCThreads(), 10_000, 1000;
@@ -188,6 +193,11 @@ include("interface.jl")
                          chain_type = MyChain)
 
         @test all(((x, y),) -> x.as == y.as && x.bs == y.bs, zip(chains, chains2))
+
+        # Unexpected order of arguments.
+        str = "Number of chains (10) is greater than number of samples per chain (5)"
+        @test_logs (:warn, str) sample(MyModel(), MySampler(), MCMCDistributed(), 5, 10;
+                                       chain_type = MyChain)
 
         # Suppress output.
         logs, _ = collect_test_logs(; min_level=Logging.LogLevel(-1)) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,8 +141,9 @@ include("interface.jl")
 
             # Unexpected order of arguments.
             str = "Number of chains (10) is greater than number of samples per chain (5)"
-            @test_logs (:warn, str) sample(MyModel(), MySampler(), MCMCThreads(), 5, 10;
-                                           chain_type = MyChain)
+            @test_logs (:warn, str) match_mode=:any sample(MyModel(), MySampler(),
+                                                           MCMCThreads(), 5, 10;
+                                                           chain_type = MyChain)
 
             # Suppress output.
             logs, _ = collect_test_logs(; min_level=Logging.LogLevel(-1)) do
@@ -196,8 +197,9 @@ include("interface.jl")
 
         # Unexpected order of arguments.
         str = "Number of chains (10) is greater than number of samples per chain (5)"
-        @test_logs (:warn, str) sample(MyModel(), MySampler(), MCMCDistributed(), 5, 10;
-                                       chain_type = MyChain)
+        @test_logs (:warn, str) match_mode=:any sample(MyModel(), MySampler(),
+                                                       MCMCDistributed(), 5, 10;
+                                                       chain_type = MyChain)
 
         # Suppress output.
         logs, _ = collect_test_logs(; min_level=Logging.LogLevel(-1)) do


### PR DESCRIPTION
On Slack it was suggested that it might be helpful if users are presented with a warning if they (probably unintentionally) specify more chains than number of samples in parallel sampling.

In general, I think the problem indicates that maybe both the number of samples and number chains should be keyword arguments (they are not used for dispatching and I can hardly imagine any downstream code would want to dispatch on them). We could present the warning for now and keep this in mind/include it in the next breaking release.