### PR TITLE
Fix undefined reference error when type widening

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -151,7 +151,6 @@ function save!!(
     ::AbstractSampler;
     kwargs...
 )
-    @assert length(transitions) == iteration - 1
     return BangBang.push!!(transitions, transition)
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -125,12 +125,11 @@ Save the `transition` of the MCMC `sampler` at the current `iteration` in the co
 `transitions`.
 
 The function can be called with and without a predefined size `N`. By default, AbstractMCMC
-uses ``setindex!`` and ``push!!`` from the Julia package
-[BangBang](https://github.com/tkf/BangBang.jl) to write to and append to the container,
-and widen the container type if needed.
+uses ``push!!`` from the Julia package [BangBang](https://github.com/tkf/BangBang.jl) to
+append to the container, and widen its type if needed.
 """
 function save!!(
-    transitions,
+    transitions::Vector,
     transition,
     iteration::Integer,
     ::AbstractModel,
@@ -139,7 +138,7 @@ function save!!(
     kwargs...
 )
     new_ts = BangBang.push!!(transitions, transition)
-    typeof(new_ts) !== typeof(transitions) && Base.sizehint!(new_ts, N)
+    new_ts !== transitions && sizehint!(new_ts, N)
     return new_ts
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -104,7 +104,7 @@ function transitions(
     kwargs...
 )
     ts = Vector{typeof(transition)}(undef, 0)
-    Base.sizehint!(ts, N)
+    sizehint!(ts, N)
     return ts
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -103,7 +103,9 @@ function transitions(
     N::Integer;
     kwargs...
 )
-    return Vector{typeof(transition)}(undef, N)
+    ts = Vector{typeof(transition)}(undef, 0)
+    Base.sizehint!(ts, N)
+    return ts
 end
 
 function transitions(
@@ -112,7 +114,7 @@ function transitions(
     ::AbstractSampler;
     kwargs...
 )
-    return Vector{typeof(transition)}(undef, 1)
+    return Vector{typeof(transition)}(undef, 0)
 end
 
 """
@@ -133,10 +135,13 @@ function save!!(
     iteration::Integer,
     ::AbstractModel,
     ::AbstractSampler,
-    ::Integer;
+    N::Integer;
     kwargs...
 )
-    return BangBang.setindex!!(transitions, transition, iteration)
+    @assert length(transitions) == iteration - 1
+    new_ts = BangBang.push!!(transitions, transition)
+    typeof(new_ts) !== typeof(transitions) && Base.sizehint!(new_ts, N)
+    return new_ts
 end
 
 function save!!(
@@ -147,6 +152,7 @@ function save!!(
     ::AbstractSampler;
     kwargs...
 )
+    @assert length(transitions) == iteration - 1
     return BangBang.push!!(transitions, transition)
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -138,7 +138,6 @@ function save!!(
     N::Integer;
     kwargs...
 )
-    @assert length(transitions) == iteration - 1
     new_ts = BangBang.push!!(transitions, transition)
     typeof(new_ts) !== typeof(transitions) && Base.sizehint!(new_ts, N)
     return new_ts
@@ -160,4 +159,3 @@ Base.@deprecate transitions_init(transition, model::AbstractModel, sampler::Abst
 Base.@deprecate transitions_init(transition, model::AbstractModel, sampler::AbstractSampler; kwargs...) transitions(transition, model, sampler; kwargs...) false
 Base.@deprecate transitions_save!(transitions, iteration::Integer, transition, model::AbstractModel, sampler::AbstractSampler; kwargs...) save!!(transitions, transition, iteration, model, sampler; kwargs...) false
 Base.@deprecate transitions_save!(transitions, iteration::Integer, transition, model::AbstractModel, sampler::AbstractSampler, N::Integer; kwargs...) save!!(transitions, transition, iteration, model, sampler, N; kwargs...) false
-


### PR DESCRIPTION
While testing stochastic control flow in Turing and DynamicPPL, I ran into an issue where `BangBang.setindex!!` tries to copy all of the old vector of transitions. Some of the elements of this vector would be undefined so it would throw and undefined reference error. This PR uses `BangBang.push!!` and `sizehint!` instead.