### PR TITLE
Add `chainsstack`

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,9 +1,23 @@
 """
-    chainscat(c::AbstractChains)
+    chainscat(c::AbstractChains...)
 
 Concatenate multiple chains.
+
+By default, the chains are concatenated along the third dimension by calling
+`cat(c...; dims=3)`.
 """
 chainscat(c::AbstractChains...) = cat(c...; dims=3)
+
+"""
+    chainsstack(c::AbstractVector)
+
+Stack chains in `c`.
+
+By default, the vector of chains is returned unmodified. If `eltype(c) <: AbstractChains`,
+then `reduce(chainscat, c)` is called.
+"""
+chainsstack(c) = c
+chainsstack(c::AbstractVector{<:AbstractChains}) = reduce(chainscat, c)
 
 """
     bundle_samples(samples, model, sampler, state, chain_type[; kwargs...])

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -250,7 +250,7 @@ function mcmcsample(
     end
 
     # Concatenate the chains together.
-    return reduce(chainscat, chains)
+    return chainsstack(tighten_eltype(chains))
 end
 
 function mcmcsample(
@@ -322,5 +322,8 @@ function mcmcsample(
     end
 
     # Concatenate the chains together.
-    return reduce(chainscat, chains)
+    return chainsstack(tighten_eltype(chains))
 end
+
+tighten_eltype(x) = x
+tighten_eltype(x::Vector{Any}) = map(identity, x)

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -95,11 +95,17 @@
             if Threads.nthreads() == 1
                 warnregex = r"^Only a single thread available"
                 @test_logs (:warn, warnregex) sample(MyModel(), MySampler(), MCMCThreads(),
-                                                     10, 10; chain_type = MyChain)
+                                                     10, 10)
             end
 
-            Random.seed!(1234)
+            # No dedicated chains type
             N = 10_000
+            chains = sample(MyModel(), MySampler(), MCMCThreads(), N, 1000)
+            @test chains isa Vector{<:Vector{<:MySample}}
+            @test length(chains) == 1000
+            @test all(length(x) == N for x in chains)
+
+            Random.seed!(1234)
             chains = sample(MyModel(), MySampler(), MCMCThreads(), N, 1000;
                             chain_type = MyChain)
 
@@ -161,7 +167,13 @@
             include("utils.jl")
         end
 
+        # No dedicated chains type
         N = 10_000
+        chains = sample(MyModel(), MySampler(), MCMCThreads(), N, 1000)
+        @test chains isa Vector{<:Vector{<:MySample}}
+        @test length(chains) == 1000
+        @test all(length(x) == N for x in chains)
+
         Random.seed!(1234)
         chains = sample(MyModel(), MySampler(), MCMCDistributed(), N, 1000;
                         chain_type = MyChain)


### PR DESCRIPTION
This PR tries to address https://github.com/TuringLang/AbstractMCMC.jl/issues/44 by adding a method for (hopefully) concretizing arrays of type `Vector{Any}` and a `chainsstack(x::AbstractVector)` that falls back to `reduce(chainscat, x)` or `x`, depending on whether `eltype(x) <: AbstractChains` or not.