### PR TITLE
Provide generic implementation of `bundle_samples` for `Vector{T}`

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -26,6 +26,19 @@ function bundle_samples(
     return samples
 end
 
+function bundle_samples(
+    samples::Vector,
+    ::AbstractModel,
+    ::AbstractSampler,
+    ::Any,
+    ::Type{Vector{T}};
+    kwargs...
+) where T
+    return map(samples) do sample
+        convert(T, sample)
+    end
+end
+
 """
     step(rng, model, sampler[, state; kwargs...])
 

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -214,4 +214,19 @@
         bmean = mean(x.b for x in chain)
         @test abs(bmean) <= 0.001 && length(chain) < 10_000
     end
+
+    @testset "Sample vector of `NamedTuple`s" begin
+        chain = sample(MyModel(), MySampler(), 1_000; chain_type = Vector{NamedTuple})
+        # Check output type
+        @test chain isa Vector{<:NamedTuple}
+        @test length(chain) == 1_000
+        @test all(keys(x) == (:a, :b) for x in chain)
+
+        # Check some statistical properties
+        @test ismissing(chain[1].a)
+        @test mean(x.a for x in view(chain, 2:1_000)) ≈ 0.5 atol=6e-2
+        @test var(x.a for x in view(chain, 2:1_000)) ≈ 1 / 12 atol=5e-3
+        @test mean(x.b for x in chain) ≈ 0.0 atol=5e-2
+        @test var(x.b for x in chain) ≈ 1 atol=6e-2
+    end
 end

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -227,6 +227,6 @@
         @test mean(x.a for x in view(chain, 2:1_000)) ≈ 0.5 atol=6e-2
         @test var(x.a for x in view(chain, 2:1_000)) ≈ 1 / 12 atol=5e-3
         @test mean(x.b for x in chain) ≈ 0.0 atol=5e-2
-        @test var(x.b for x in chain) ≈ 1 atol=6e-2
+        @test var(x.b for x in chain) ≈ 1 atol=0.15
     end
 end

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -226,7 +226,7 @@
         @test ismissing(chain[1].a)
         @test mean(x.a for x in view(chain, 2:1_000)) ≈ 0.5 atol=6e-2
         @test var(x.a for x in view(chain, 2:1_000)) ≈ 1 / 12 atol=5e-3
-        @test mean(x.b for x in chain) ≈ 0.0 atol=5e-2
+        @test mean(x.b for x in chain) ≈ 0 atol=0.1
         @test var(x.b for x in chain) ≈ 1 atol=0.15
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -72,3 +72,6 @@ function AbstractMCMC.chainscat(
 )
     return vcat(chain, chains...)
 end
+
+# Conversion to NamedTuple
+Base.convert(::Type{NamedTuple}, x::MySample) = (a = x.a, b = x.b)


### PR DESCRIPTION
While updating AdvancedMH I noticed that we define a bunch of `bundle_samples` implementations there. I was wondering if we could generalize that in a way such that we don't have to repeat it in every package. In particular, it seems a bit strange to reimplement it in every package for `Vector{NamedTuple}` even though the only difference is how the samples are converted to a `NamedTuple`. But one could, e.g., also have a generic version for MCMCChains.Chains in MCMCChains with the basic structure + an interface for other packages to convert the samples, retrieve the names, the log-evidence + save the state, sampler, and model in a standardized way (and not different in every package).

This PR contains a very generic implementation for any desired vector-valued output.