### PR TITLE
Fixed missing semi-colon for kwargs in `steps`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/src/stepper.jl
+++ b/src/stepper.jl
@@ -30,7 +30,7 @@ end
 """
 function steps(
     model::AbstractModel,
-    sampler::AbstractSampler,
+    sampler::AbstractSampler;
     kwargs...
 )
     return steps(Random.GLOBAL_RNG, model, sampler; kwargs...)
@@ -39,7 +39,7 @@ end
 function steps(
     rng::Random.AbstractRNG,
     model::AbstractModel,
-    sampler::AbstractSampler,
+    sampler::AbstractSampler;
     kwargs...
 )
     return Stepper(rng, model, sampler, kwargs)

--- a/test/stepper.jl
+++ b/test/stepper.jl
@@ -5,6 +5,7 @@
         bs = []
 
         iter = AbstractMCMC.steps(MyModel(), MySampler())
+        iter = AbstractMCMC.steps(MyModel(), MySampler(); a = 1.0) # `a` shouldn't do anything
 
         for (count, t) in enumerate(iter)
             if count >= 1000


### PR DESCRIPTION
This really seems like a bug to me, but maybe I'm just brainfarting at 1am (it has happened before).