### PR TITLE
Allow to enable and disable progress logging globally

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ returns a transducer that returns samples continuously.
 
 Common keyword arguments for regular and parallel sampling (not supported by the iterator and transducer)
 are:
-- `progress` (default: `true`):  toggles progress logging
+- `progress` (default: `AbstractMCMC.PROGRESS[]` which is `true` initially):  toggles progress logging
 - `chain_type` (default: `Any`): determines the type of the returned chain
 - `callback` (default: `nothing`): if `callback !== nothing`, then
   `callback(rng, model, sampler, sample, iteration)` is called after every sampling step,
   where `sample` is the most recent sample of the Markov chain and `iteration` is the current iteration
 - `discard_initial` (default: `0`): number of initial samples that are discarded
 - `thinning` (default: `1`): factor by which to thin samples.
+
+Progress logging can be enabled and disabled globally with `AbstractMCMC.setprogress!(progress)`.
 
 Additionally, AbstractMCMC defines the abstract type `AbstractChains` for Markov chains and the
 method `AbstractMCMC.chainscat(::AbstractChains...)` for concatenating multiple chains.

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -1,4 +1,16 @@
 # Default implementations of `sample`.
+const PROGRESS = Ref(true)
+
+"""
+    setprogress!(progress::Bool)
+
+Enable progress logging globally if `progress` is `true`, and disable it otherwise.
+"""
+function setprogress!(progress::Bool)
+    @info "progress logging is $(progress ? "enabled" : "disabled") globally"
+    PROGRESS[] = progress
+    return progress
+end
 
 function StatsBase.sample(
     model::AbstractModel,
@@ -61,7 +73,7 @@ function mcmcsample(
     model::AbstractModel,
     sampler::AbstractSampler,
     N::Integer;
-    progress = true,
+    progress = PROGRESS[],
     progressname = "Sampling",
     callback = nothing,
     discard_initial = 0,
@@ -154,7 +166,7 @@ function mcmcsample(
     sampler::AbstractSampler,
     isdone;
     chain_type::Type=Any,
-    progress = true,
+    progress = PROGRESS[],
     progressname = "Convergence sampling",
     callback = nothing,
     discard_initial = 0,
@@ -219,7 +231,7 @@ function mcmcsample(
     ::MCMCThreads,
     N::Integer,
     nchains::Integer;
-    progress = true,
+    progress = PROGRESS[],
     progressname = "Sampling ($(min(nchains, Threads.nthreads())) threads)",
     kwargs...
 )
@@ -302,7 +314,7 @@ function mcmcsample(
     ::MCMCDistributed,
     N::Integer,
     nchains::Integer;
-    progress = true,
+    progress = PROGRESS[],
     progressname = "Sampling ($(Distributed.nworkers()) processes)",
     kwargs...
 )

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -87,6 +87,19 @@
                 sample(MyModel(), MySampler(), 100; progress = false, sleepy = true)
             end
             @test all(l.level > Logging.LogLevel(-1) for l in logs)
+
+            # disable progress logging globally
+            @test !(@test_logs (:info, "progress logging is disabled globally") AbstractMCMC.setprogress!(false))
+            @test !AbstractMCMC.PROGRESS[]
+
+            logs, _ = collect_test_logs(; min_level=Logging.LogLevel(-1)) do
+                sample(MyModel(), MySampler(), 100; sleepy = true)
+            end
+            @test all(l.level > Logging.LogLevel(-1) for l in logs)
+
+            # enable progress logging globally
+            @test (@test_logs (:info, "progress logging is enabled globally") AbstractMCMC.setprogress!(true))
+            @test AbstractMCMC.PROGRESS[]
         end
     end
 


### PR DESCRIPTION
This PR moves the `setprogress!` logic from Turing upstream. IMO it belongs here since it allows to tune the default keyword arguments. The change is non-breaking since the default is not changed and it can be specified in the `sample`/`mcmcsample` calls as before.

Some additional background:
The main reason for `mcmcsample` is that Turing wants to use different default keyword arguments for `sample` but I guess it might be better to allow to set or define the keyword arguments instead. E.g., by adding an additional `default_chain_type(model, sampler) = Any` function that could be implemented as `default_chain_type(::Model, ::Sampler{<:InferenceAlgorithm}) = Chain` in Turing.