### PR TITLE
Limit update frequency of progress bars

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -85,13 +85,14 @@ function mcmcsample(
     N > 0 || error("the number of samples must be ≥ 1")
     Ntotal = thinning * (N - 1) + discard_initial + 1
 
-    # Determine threshold values for progress logging (one update per 0.5% of progress)
-    if progress
-        threshold = Ntotal ÷ 200
-        next_update = threshold
-    end
-
     @ifwithprogresslogger progress name=progressname begin
+        # Determine threshold values for progress logging
+        # (one update per 0.5% of progress)
+        if progress
+            threshold = Ntotal ÷ 200
+            next_update = threshold
+        end
+
         # Obtain the initial sample and state.
         sample, state = step(rng, model, sampler; kwargs...)
 


### PR DESCRIPTION
This PR limits the update frequency of the progress bars to one update per 0.5% progress. This is the default value of [`@progress`](https://junolab.org/ProgressLogging.jl/dev/#ProgressLogging.@progress-Tuple). Progress logging is quite slow and therefore this should speed up sampling.