### PR TITLE
Use TerminalLoggers also on Windows for Julia >= 1.5.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "2.4.0"
+version = "2.5.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -37,7 +37,7 @@ end
 function progresslogger()
     # detect if code is running under IJulia since TerminalLogger does not work with IJulia
     # https://github.com/JuliaLang/IJulia.jl#detecting-that-code-is-running-under-ijulia
-    if Sys.iswindows() || (isdefined(Main, :IJulia) && Main.IJulia.inited)
+    if (Sys.iswindows() && VERSION < v"1.5.3") || (isdefined(Main, :IJulia) && Main.IJulia.inited)
         return ConsoleProgressMonitor.ProgressLogger()
     else
         return TerminalLoggers.TerminalLogger()

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -10,7 +10,7 @@
             @test length(LOGGERS) == 1
             logger = first(LOGGERS)
             @test logger isa TeeLogger
-            @test logger.loggers[1].logger isa (Sys.iswindows() ? ProgressLogger : TerminalLogger)
+            @test logger.loggers[1].logger isa (Sys.iswindows() && VERSION < v"1.5.3" ? ProgressLogger : TerminalLogger)
             @test logger.loggers[2].logger === CURRENT_LOGGER
             @test Logging.current_logger() === CURRENT_LOGGER
 


### PR DESCRIPTION
It seems TerminalLoggers can be used for rendering progress bars on Windows with recent versions of Julia: https://c42f.github.io/TerminalLoggers.jl/dev/#Progress-bars-1

I don't have access to a computer with Windows, so it would be good if someone could confirm that it works fine before merging the PR.