### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -1,0 +1,50 @@
+name: IntegrationTest
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - {user: TuringLang, repo: AdvancedMH.jl}
+          - {user: TuringLang, repo: EllipticalSliceSampling.jl}
+          - {user: TuringLang, repo: MCMCChains.jl}
+          #- {user: TuringLang, repo: Turing.jl}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone Downstream
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          path: downstream
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine
+            # It means we marked this as a breaking change, so we don't need to worry about
+            # Mistakenly introducing a breaking change, as we have intentionally made one
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Abstract types and interfaces for Markov chain Monte Carlo methods.
 
-![CI](https://github.com/TuringLang/AbstractMCMC.jl/workflows/CI/badge.svg?branch=master)
+[![CI](https://github.com/TuringLang/AbstractMCMC.jl/workflows/CI/badge.svg?branch=master)](https://github.com/TuringLang/AbstractMCMC.jl/actions?query=workflow%3ACI+branch%3Amaster)
+[![IntegrationTest](https://github.com/TuringLang/AbstractMCMC.jl/workflows/IntegrationTest/badge.svg?branch=master)](https://github.com/TuringLang/AbstractMCMC.jl/actions?query=workflow%3AIntegrationTest+branch%3Amaster)
 [![Codecov](https://codecov.io/gh/TuringLang/AbstractMCMC.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/TuringLang/AbstractMCMC.jl)
 [![Coveralls](https://coveralls.io/repos/github/TuringLang/AbstractMCMC.jl/badge.svg?branch=master)](https://coveralls.io/github/TuringLang/AbstractMCMC.jl?branch=master)
 


### PR DESCRIPTION
This PR adds downstream tests to avoid any unintentional breakage of the interface. More packages (in particular Turing) could be added but to avoid excessive test times it would be helpful if these repos would support running a subset of tests, such as e.g. in Bijectors (inspired by SciML) with a `GROUP` environment variable: https://github.com/TuringLang/Bijectors.jl/blob/ad6b01c4a214562ef845ab3b5a0a296b348e1ba9/test/runtests.jl#L29