### PR TITLE
Add Metadata struct

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ version = "2.5.0"
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 ConsoleProgressMonitor = "88cd18e8-d9cc-4ea6-8889-5259c0d15c8b"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ version = "2.6.0"
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 ConsoleProgressMonitor = "88cd18e8-d9cc-4ea6-8889-5259c0d15c8b"
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"

--- a/README.md
+++ b/README.md
@@ -181,5 +181,7 @@ where `samples` is the collection of samples, `state` is the final state of the 
 and `chain_type` is the desired return type. The default implementation in AbstractMCMC
 just returns the collection `samples`.
 
+`sample` will log the start and stop time (in Unix timestamp format) for a chain, and pass the sampling statistics to the chain with `bundle_samples(...; stats=stats)`. The sample time information can be retrieved with `stats.start`, `stats.stop`, and `stats.duration`.
+
 The default implementation should be fine in most use cases, but downstream packages
 could, e.g., save the final state of the sampler as well if they overload `AbstractMCMC.bundle_samples`.

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -71,7 +71,7 @@ processes.
 """
 struct MCMCDistributed <: AbstractMCMCParallel end
 
-include("metadata.jl")
+include("samplingstats.jl")
 include("logging.jl")
 include("interface.jl")
 include("sample.jl")

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -71,6 +71,7 @@ processes.
 """
 struct MCMCDistributed <: AbstractMCMCParallel end
 
+include("metadata.jl")
 include("logging.jl")
 include("interface.jl")
 include("sample.jl")

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -24,7 +24,7 @@ end
 Metadata() = Metadata(Dates.now(), missing, 0,0,0)
 
 function update(f, md::Metadata)
-    value, stats... = @timed f(md)
+    (value, stats...) = @timed f(md)
 
     md.step_time += stats.time
     md.step_calls += 1

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -1,6 +1,18 @@
 using Dates
 
-# Tracks sampling metadata
+"""
+    Metadata
+
+A struct that tracks sampling information. 
+
+The fields available are:
+
+- `start_time`: A `DateTime` indicating when sampling begun.
+- `stop_time`: A `DateTime` indicating when sampling finished.
+- `step_calls`: The number of times `step!` was called.
+- `step_time`: The total number of seconds spent inside `step!` calls.
+- `allocations`: The total number of bytes allocated by `step!`.
+"""
 mutable struct Metadata
     start_time::DateTime
     stop_time::Union{DateTime, Missing}

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -24,11 +24,11 @@ end
 Metadata() = Metadata(Dates.now(), missing, 0,0,0)
 
 function update(f, md::Metadata)
-    (value, stats...) = @timed f(md)
+    value, etime, alloc, gct, _ = @timed f(md)
 
-    md.step_time += stats.time
+    md.step_time += etime
     md.step_calls += 1
-    md.allocations += stats.bytes
+    md.allocations += alloc
 
     return value
 end

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -24,13 +24,13 @@ end
 Metadata() = Metadata(Dates.now(), missing, 0,0,0)
 
 function update(f, md::Metadata)
-    value, etime, alloc, gct, _ = @timed f(md)
+    (sample, state), etime, alloc, gct, _ = @timed f(md)
 
     md.step_time += etime
     md.step_calls += 1
     md.allocations += alloc
 
-    return value
+    return (sample, state)
 end
 
 function stop(md::Metadata)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -1,0 +1,26 @@
+using Dates
+
+# Tracks sampling metadata
+mutable struct Metadata
+    start_time::DateTime
+    stop_time::Union{DateTime, Missing}
+    step_time::Float64
+    step_calls::Int64
+    allocations::Int64
+end
+
+Metadata() = Metadata(Dates.now(), missing, 0,0,0)
+
+function update(f, md::Metadata)
+    value, stats... = @timed f(md)
+
+    md.step_time += stats.time
+    md.step_calls += 1
+    md.allocations += stats.bytes
+
+    return value
+end
+
+function stop(md::Metadata)
+    md.stop_time = Dates.now()
+end

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -87,6 +87,7 @@ function mcmcsample(
 
     # Start the timer
     start = time()
+    local state
 
     allocations = @allocated begin
         @ifwithprogresslogger progress name=progressname begin
@@ -207,6 +208,7 @@ function mcmcsample(
 
     # Start the timer
     start = time()
+    local state
 
     allocations = @allocated begin
         @ifwithprogresslogger progress name=progressname begin

--- a/src/samplingstats.jl
+++ b/src/samplingstats.jl
@@ -5,15 +5,14 @@ A struct that tracks sampling information.
 
 The fields available are:
 
-- `start_time`: A `DateTime` indicating when sampling begun.
-- `stop_time`: A `DateTime` indicating when sampling finished.
-- `step_calls`: The number of times `step!` was called.
-- `step_time`: The total number of seconds spent inside `step!` calls.
-- `allocations`: The total number of bytes allocated by `step!`.
+- `start`: A `Float64` Unix timestamp indicating the start time of sampling.
+- `stop`: A `Float64` Unix timestamp indicating the stop time of sampling.
+- `duration`: The sampling time duration, defined as `stop - start`.
+- `allocations`: The total number of bytes allocated by the sampling process.
 """
 struct SamplingStats
     start::Float64
-    stop::Union{Float64, Missing}
-    duration::Union{Float64, Missing}
+    stop::Float64
+    duration::Float64
     allocations::Int64
 end

--- a/src/samplingstats.jl
+++ b/src/samplingstats.jl
@@ -11,7 +11,7 @@ The fields available are:
 - `step_time`: The total number of seconds spent inside `step!` calls.
 - `allocations`: The total number of bytes allocated by `step!`.
 """
-mutable struct SamplingStats
+struct SamplingStats
     start::Float64
     stop::Union{Float64, Missing}
     duration::Union{Float64, Missing}

--- a/src/samplingstats.jl
+++ b/src/samplingstats.jl
@@ -8,11 +8,9 @@ The fields available are:
 - `start`: A `Float64` Unix timestamp indicating the start time of sampling.
 - `stop`: A `Float64` Unix timestamp indicating the stop time of sampling.
 - `duration`: The sampling time duration, defined as `stop - start`.
-- `allocations`: The total number of bytes allocated by the sampling process.
 """
 struct SamplingStats
     start::Float64
     stop::Float64
     duration::Float64
-    allocations::Int64
 end

--- a/src/samplingstats.jl
+++ b/src/samplingstats.jl
@@ -1,7 +1,5 @@
-using Dates
-
 """
-    Metadata
+    SamplingStats
 
 A struct that tracks sampling information. 
 
@@ -13,17 +11,16 @@ The fields available are:
 - `step_time`: The total number of seconds spent inside `step!` calls.
 - `allocations`: The total number of bytes allocated by `step!`.
 """
-mutable struct Metadata
-    start_time::DateTime
-    stop_time::Union{DateTime, Missing}
+mutable struct SamplingStats
+    start::Float64
+    stop::Union{Float64, Missing}
+    duration::Union{Float64, Missing}
     step_time::Float64
     step_calls::Int64
     allocations::Int64
 end
 
-Metadata() = Metadata(Dates.now(), missing, 0,0,0)
-
-function update(f, md::Metadata)
+function update(f, md::SamplingStats)
     (sample, state), etime, alloc, gct, _ = @timed f(md)
 
     md.step_time += etime
@@ -33,6 +30,6 @@ function update(f, md::Metadata)
     return (sample, state)
 end
 
-function stop(md::Metadata)
+function stop(md::SamplingStats)
     md.stop_time = Dates.now()
 end

--- a/src/samplingstats.jl
+++ b/src/samplingstats.jl
@@ -15,21 +15,5 @@ struct SamplingStats
     start::Float64
     stop::Union{Float64, Missing}
     duration::Union{Float64, Missing}
-    step_time::Float64
-    step_calls::Int64
     allocations::Int64
-end
-
-function update(f, md::SamplingStats)
-    (sample, state), etime, alloc, gct, _ = @timed f(md)
-
-    md.step_time += etime
-    md.step_calls += 1
-    md.allocations += alloc
-
-    return (sample, state)
-end
-
-function stop(md::SamplingStats)
-    md.stop_time = Dates.now()
 end

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -238,25 +238,7 @@
         
         @test chain.stats.stop > chain.stats.start
         @test chain.stats.duration == chain.stats.stop - chain.stats.start
-        @test chain.stats.step_calls == 1000
         @test chain.stats.allocations > 0
-        @test chain.stats.step_time <= chain.stats.duration
-
-        # Test that thinning/initial discard samples are caught correctly
-        chain2 = sample(
-            MyModel(),
-            MySampler(), 
-            1000; 
-            chain_type = MyChain, 
-            thinning = 2, 
-            discard_initial=100
-        )
-
-        # Formula:
-        #   thinning * (N - 1) + discard_initial + 1
-        #   2 * (999) + 100 + 1 = 2099
-        @test chain2.stats.step_calls == 2099 
-        @test chain2.stats.step_time > chain.stats.step_time
     end
 
     @testset "Discard initial samples" begin

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -238,7 +238,6 @@
         
         @test chain.stats.stop > chain.stats.start
         @test chain.stats.duration == chain.stats.stop - chain.stats.start
-        @test chain.stats.allocations > 0
     end
 
     @testset "Discard initial samples" begin

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -233,6 +233,15 @@
         @test chain2 isa MyChain
     end
 
+    @testset "Metadata" begin
+        chain = sample(MyModel(), MySampler(), 1000; chain_type = MyChain)
+        
+        @test chain.metadata.stop_time > chain.metadata.start_time
+        @test chain.metadata.step_calls == 1000
+        @test chain.metadata.allocations > 0
+        @test chain.metadata.step_time > 0
+    end
+
     @testset "Discard initial samples" begin
         chain = sample(MyModel(), MySampler(), 100; sleepy = true, discard_initial = 50)
         @test length(chain) == 100

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -8,10 +8,10 @@ end
 struct MySampler <: AbstractMCMC.AbstractSampler end
 struct AnotherSampler <: AbstractMCMC.AbstractSampler end
 
-struct MyChain{A,B,M} <: AbstractMCMC.AbstractChains
+struct MyChain{A,B,S} <: AbstractMCMC.AbstractChains
     as::Vector{A}
     bs::Vector{B}
-    metadata::M
+    stats::S
 end
 
 MyChain(a, b) = MyChain(a, b, NamedTuple())
@@ -43,13 +43,13 @@ function AbstractMCMC.bundle_samples(
     sampler::MySampler,
     ::Any,
     ::Type{MyChain};
-    sampling_metadata = nothing,
+    stats = nothing,
     kwargs...
 )
     as = [t.a for t in samples]
     bs = [t.b for t in samples]
 
-    return MyChain(as, bs, sampling_metadata)
+    return MyChain(as, bs, stats)
 end
 
 function isdone(

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -8,10 +8,13 @@ end
 struct MySampler <: AbstractMCMC.AbstractSampler end
 struct AnotherSampler <: AbstractMCMC.AbstractSampler end
 
-struct MyChain{A,B} <: AbstractMCMC.AbstractChains
+struct MyChain{A,B,M} <: AbstractMCMC.AbstractChains
     as::Vector{A}
     bs::Vector{B}
+    metadata::M
 end
+
+MyChain(a, b) = MyChain(a, b, NamedTuple())
 
 function AbstractMCMC.step(
     rng::AbstractRNG,
@@ -40,12 +43,13 @@ function AbstractMCMC.bundle_samples(
     sampler::MySampler,
     ::Any,
     ::Type{MyChain};
+    sampling_metadata = nothing,
     kwargs...
 )
     as = [t.a for t in samples]
     bs = [t.b for t in samples]
 
-    return MyChain(as, bs)
+    return MyChain(as, bs, sampling_metadata)
 end
 
 function isdone(


### PR DESCRIPTION
This PR adds a `Metadata` struct that tracks the following information:

1. Start time
2. Stop time
3. Step time (time spent per step)
4. Step calls (how many times `step!` was called)
5. Allocations

It's created and passed as a keyword argument to `bundle_samples`, so it remains up to end-chain software to determine what to do (if anything) with the metadata.