### PR TITLE
Add MCMCSerial

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "3.1.0"
+version = "3.2.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,7 +28,7 @@ AbstractMCMC.sample(
     ::AbstractRNG,
     ::AbstractMCMC.AbstractModel,
     ::AbstractMCMC.AbstractSampler,
-    ::AbstractMCMC.AbstractMCMCParallel,
+    ::AbstractMCMC.AbstractMCMCEnsemble,
     ::Integer,
     ::Integer,
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,11 +34,11 @@ AbstractMCMC.sample(
 )
 ```
 
-Two algorithms are provided for parallel sampling with multiple threads and multiple processes,
-respectively:
+Two algorithms are provided for parallel sampling with multiple threads and multiple processes, and one allows for the user to sample multiple chains in serial (no parallelization):
 ```@docs
 AbstractMCMC.MCMCThreads
 AbstractMCMC.MCMCDistributed
+AbstractMCMC.MCMCSerial
 ```
 
 ## Common keyword arguments

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -55,9 +55,6 @@ in parallel.
 """
 abstract type AbstractMCMCEnsemble end
 
-# Deprecate the old name AbstractMCMCParallel in favor of AbstractMCMCEnsemble
-Base.@deprecate_binding AbstractMCMCParallel AbstractMCMCEnsemble false
-
 """
     MCMCThreads
 
@@ -88,5 +85,6 @@ include("interface.jl")
 include("sample.jl")
 include("stepper.jl")
 include("transducer.jl")
+include("deprecations.jl")
 
 end # module AbstractMCMC

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -48,12 +48,15 @@ An `AbstractModel` represents a generic model type that can be used to perform i
 abstract type AbstractModel end
 
 """
-    AbstractMCMCParallel
+    AbstractMCMCEnsemble
 
-An `AbstractMCMCParallel` algorithm represents a specific algorithm for sampling MCMC chains
+An `AbstractMCMCEnsemble` algorithm represents a specific algorithm for sampling MCMC chains
 in parallel.
 """
-abstract type AbstractMCMCParallel end
+abstract type AbstractMCMCEnsemble end
+
+# Deprecate the old name AbstractMCMCParallel in favor of AbstractMCMCEnsemble
+Base.@deprecate_binding AbstractMCMCParallel AbstractMCMCEnsemble false
 
 """
     MCMCThreads
@@ -61,7 +64,7 @@ abstract type AbstractMCMCParallel end
 The `MCMCThreads` algorithm allows users to sample MCMC chains in parallel using multiple
 threads.
 """
-struct MCMCThreads <: AbstractMCMCParallel end
+struct MCMCThreads <: AbstractMCMCEnsemble end
 
 """
     MCMCDistributed
@@ -69,7 +72,7 @@ struct MCMCThreads <: AbstractMCMCParallel end
 The `MCMCDistributed` algorithm allows users to sample MCMC chains in parallel using multiple
 processes.
 """
-struct MCMCDistributed <: AbstractMCMCParallel end
+struct MCMCDistributed <: AbstractMCMCEnsemble end
 
 
 """
@@ -77,7 +80,7 @@ struct MCMCDistributed <: AbstractMCMCParallel end
 
 The `MCMCSerial` algorithm allows users to sample serially, with no thread or process parallelism.
 """
-struct MCMCSerial <: AbstractMCMCParallel end
+struct MCMCSerial <: AbstractMCMCEnsemble end
 
 include("samplingstats.jl")
 include("logging.jl")

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -17,7 +17,7 @@ using StatsBase: sample
 export sample
 
 # Parallel sampling types
-export MCMCThreads, MCMCDistributed
+export MCMCThreads, MCMCDistributed, MCMCSerial
 
 """
     AbstractChains

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -58,7 +58,7 @@ abstract type AbstractMCMCParallel end
 """
     MCMCThreads
 
-The `MCMCThreads` algorithm allows to sample MCMC chains in parallel using multiple
+The `MCMCThreads` algorithm allows users to sample MCMC chains in parallel using multiple
 threads.
 """
 struct MCMCThreads <: AbstractMCMCParallel end
@@ -66,10 +66,18 @@ struct MCMCThreads <: AbstractMCMCParallel end
 """
     MCMCDistributed
 
-The `MCMCDistributed` algorithm allows to sample MCMC chains in parallel using multiple
+The `MCMCDistributed` algorithm allows users to sample MCMC chains in parallel using multiple
 processes.
 """
 struct MCMCDistributed <: AbstractMCMCParallel end
+
+
+"""
+    MCMCSerial
+
+The `MCMCSerial` algorithm allows users to sample serially, with no thread or process parallelism.
+"""
+struct MCMCSerial <: AbstractMCMCParallel end
 
 include("samplingstats.jl")
 include("logging.jl")

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,2 @@
+# Deprecate the old name AbstractMCMCParallel in favor of AbstractMCMCEnsemble
+Base.@deprecate_binding AbstractMCMCParallel AbstractMCMCEnsemble false

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -459,16 +459,12 @@ function mcmcsample(
         @warn "Number of chains ($nchains) is greater than number of samples per chain ($N)"
     end
 
-    # Set up a chains vector.
-    chains = Vector{Any}(undef, nchains)
-
-    # Sample each chain
-    for i in 1:nchains
-        # Sample a chain and save it to the vector.
-        chains[i] = StatsBase.sample(rng, model, sampler, N; 
-                                     progressname = string(progressname, " (Chain $i of $nchains)"),
-                                     kwargs...)
-    end
+    # Sample the chains.
+    chains = map(
+        i -> StatsBase.sample(rng, model, sampler, N; progressname = string(progressname, " (Chain $i of $nchains)"),
+        kwargs...),
+        1:nchains
+    )
 
     # Concatenate the chains together.
     return chainsstack(tighten_eltype(chains))

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -61,7 +61,7 @@ end
 function StatsBase.sample(
     model::AbstractModel,
     sampler::AbstractSampler,
-    parallel::AbstractMCMCParallel,
+    parallel::AbstractMCMCEnsemble,
     N::Integer,
     nchains::Integer;
     kwargs...
@@ -80,7 +80,7 @@ function StatsBase.sample(
     rng::Random.AbstractRNG,
     model::AbstractModel,
     sampler::AbstractSampler,
-    parallel::AbstractMCMCParallel,
+    parallel::AbstractMCMCEnsemble,
     N::Integer,
     nchains::Integer;
     kwargs...

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -444,5 +444,35 @@ function mcmcsample(
     return chainsstack(tighten_eltype(chains))
 end
 
+function mcmcsample(
+    rng::Random.AbstractRNG,
+    model::AbstractModel,
+    sampler::AbstractSampler,
+    ::MCMCSerial,
+    N::Integer,
+    nchains::Integer;
+    progressname = "Sampling",
+    kwargs...
+)
+    # Check if the number of chains is larger than the number of samples
+    if nchains > N
+        @warn "Number of chains ($nchains) is greater than number of samples per chain ($N)"
+    end
+
+    # Set up a chains vector.
+    chains = Vector{Any}(undef, nchains)
+
+    # Sample each chain
+    for i in 1:nchains
+        # Sample a chain and save it to the vector.
+        chains[i] = StatsBase.sample(rng, model, sampler, N; 
+                                     progressname = string(progressname, " (Chain $i of $nchains)"),
+                                     kwargs...)
+    end
+
+    # Concatenate the chains together.
+    return chainsstack(tighten_eltype(chains))
+end
+
 tighten_eltype(x) = x
 tighten_eltype(x::Vector{Any}) = map(identity, x)

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -461,7 +461,7 @@ function mcmcsample(
 
     # Sample the chains.
     chains = map(
-        i -> StatsBase.sample(rng, model, sampler, N; progressname = string(progressname, " (Chain $i of $nchains)"),
+        i -> StatsBase.sample(rng, model, sampler, N; progressname = string(progressname, " (Chain ", i, " of ", nchains, ")"),
         kwargs...),
         1:nchains
     )


### PR DESCRIPTION
I often run into the case where I want to get multiple chains but don't want to go through the hassle of making things threadsafe or available to each process. The common way to do this currently is something like

```julia
chains = map(x -> sample(model, spl, n), 1:10) # sample ten chains
chain = reduce(chainscat, chains)
```

Which is fine, but it is odd that we don't have a convenient way of sampling multiple chains in a basic way. 

I added `MCMCSerial` as a parallelization subtype, so you can now simply call

```julia
chain = sample(model, spl, MCMCSerial(), n, 10)
```

which will sample each subchain in turn and concatenate them. Tests are included.

I'm also open to changing the call here --  it seems to me that this should be the default behavior of something like

```julia
sample(model, spl, n, n_chains)
```

where no parallization method is specified. I haven't implemented the signature above but I can if people think it's a good idea.