### PR TITLE
Ensure ensemble sampling is reproducible

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,6 +46,8 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+        with:
+          cache-packages: "false" # caching Conda.jl causes precompilation error
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         env:

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "3.3.0"
+version = "3.3.1"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "3.3.1"
+version = "3.3.2"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -130,7 +130,7 @@
         @test all(x -> isapprox(mean(@view x.as[2:end]), 0.5; atol=5e-2), chains)
         @test all(x -> isapprox(var(@view x.as[2:end]), 1 / 12; atol=5e-3), chains)
         @test all(x -> isapprox(mean(@view x.bs[2:end]), 0; atol=5e-2), chains)
-        @test all(x -> isapprox(var(@view x.bs[2:end]), 1; atol=5e-2), chains)
+        @test all(x -> isapprox(var(@view x.bs[2:end]), 1; atol=1e-1), chains)
 
         # test reproducibility
         Random.seed!(1234)
@@ -199,7 +199,7 @@
         @test all(x -> isapprox(mean(@view x.as[2:end]), 0.5; atol=5e-2), chains)
         @test all(x -> isapprox(var(@view x.as[2:end]), 1 / 12; atol=5e-3), chains)
         @test all(x -> isapprox(mean(@view x.bs[2:end]), 0; atol=5e-2), chains)
-        @test all(x -> isapprox(var(@view x.bs[2:end]), 1; atol=5e-2), chains)
+        @test all(x -> isapprox(var(@view x.bs[2:end]), 1; atol=1e-1), chains)
 
         # Test reproducibility.
         Random.seed!(1234)
@@ -245,7 +245,7 @@
         @test all(x -> isapprox(mean(@view x.as[2:end]), 0.5; atol=5e-2), chains)
         @test all(x -> isapprox(var(@view x.as[2:end]), 1 / 12; atol=5e-3), chains)
         @test all(x -> isapprox(mean(@view x.bs[2:end]), 0; atol=5e-2), chains)
-        @test all(x -> isapprox(var(@view x.bs[2:end]), 1; atol=5e-2), chains)
+        @test all(x -> isapprox(var(@view x.bs[2:end]), 1; atol=1e-1), chains)
 
         # Test reproducibility.
         Random.seed!(1234)


### PR DESCRIPTION
I noticed that in #95 I accidentally introduced a reproducibility issue for multithreaded sampling: If seeds are set for each chunk (as in the PR), then the samples will depend on the number of threads. This PR fixes the issue and reverts this change: For each chain, the RNG is set to a specific reproducible seed.

Additionally, I added the same seeds to the serial sampling (they are already used in the distributed sampling). This ensures that the samples do not depend on the chosen ensemble methods. It could be removed from the PR if not desired.