### PR TITLE
More stable tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "4.1.1"
+version = "4.1.2"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/test/stepper.jl
+++ b/test/stepper.jl
@@ -48,8 +48,8 @@
         chain = sample(
             MyModel(), MySampler(), N; discard_initial=discard_initial, progress=false
         )
-        @test all(as[i] === chain[i].a for i in 1:N)
-        @test all(bs[i] === chain[i].b for i in 1:N)
+        @test all(as[i] == chain[i].a for i in 1:N)
+        @test all(bs[i] == chain[i].b for i in 1:N)
     end
 
     @testset "Thin chain by a factor of `thinning`" begin
@@ -68,7 +68,8 @@
         # Repeat sampling with `sample`.
         Random.seed!(1234)
         chain = sample(MyModel(), MySampler(), N; thinning=thinning, progress=false)
-        @test all(as[i] === chain[i].a for i in 1:N)
-        @test all(bs[i] === chain[i].b for i in 1:N)
+        @test as[1] === chain[1].a === missing
+        @test all(as[i] == chain[i].a for i in 2:N)
+        @test all(bs[i] == chain[i].b for i in 1:N)
     end
 end

--- a/test/transducer.jl
+++ b/test/transducer.jl
@@ -70,8 +70,8 @@
         chain = sample(
             MyModel(), MySampler(), N; discard_initial=discard_initial, progress=false
         )
-        @test all(as[i] === chain[i].a for i in 1:N)
-        @test all(bs[i] === chain[i].b for i in 1:N)
+        @test all(as[i] == chain[i].a for i in 1:N)
+        @test all(bs[i] == chain[i].b for i in 1:N)
     end
 
     @testset "Thin chain by a factor of `thinning`" begin
@@ -92,7 +92,8 @@
         # Repeat sampling with `sample`.
         Random.seed!(1234)
         chain = sample(MyModel(), MySampler(), N; thinning=thinning, progress=false)
-        @test all(as[i] === chain[i].a for i in 1:N)
-        @test all(bs[i] === chain[i].b for i in 1:N)
+        @test as[1] === chain[1].a === missing
+        @test all(as[i] == chain[i].a for i in 2:N)
+        @test all(bs[i] == chain[i].b for i in 1:N)
     end
 end


### PR DESCRIPTION
It seems there are still random test errors that are difficult to reproduce. It seems replacing `===` with `==` was helpful, so this PR changes it in more places (`===` was used since the initial sample of `a` is `missing` and can't be compared with `==`).