### PR TITLE
Replace `GLOBAL_RNG` with `default_rng()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "4.1.2"
+version = "4.1.3"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -13,7 +13,7 @@ function setprogress!(progress::Bool)
 end
 
 function StatsBase.sample(model::AbstractModel, sampler::AbstractSampler, arg; kwargs...)
-    return StatsBase.sample(Random.GLOBAL_RNG, model, sampler, arg; kwargs...)
+    return StatsBase.sample(Random.default_rng(), model, sampler, arg; kwargs...)
 end
 
 """
@@ -63,7 +63,7 @@ function StatsBase.sample(
     kwargs...,
 )
     return StatsBase.sample(
-        Random.GLOBAL_RNG, model, sampler, parallel, N, nchains; kwargs...
+        Random.default_rng(), model, sampler, parallel, N, nchains; kwargs...
     )
 end
 

--- a/src/stepper.jl
+++ b/src/stepper.jl
@@ -42,7 +42,7 @@ Base.IteratorSize(::Type{<:Stepper}) = Base.IsInfinite()
 Base.IteratorEltype(::Type{<:Stepper}) = Base.EltypeUnknown()
 
 function steps(model::AbstractModel, sampler::AbstractSampler; kwargs...)
-    return steps(Random.GLOBAL_RNG, model, sampler; kwargs...)
+    return steps(Random.default_rng(), model, sampler; kwargs...)
 end
 
 """

--- a/src/transducer.jl
+++ b/src/transducer.jl
@@ -7,7 +7,7 @@ struct Sample{A<:Random.AbstractRNG,M<:AbstractModel,S<:AbstractSampler,K} <:
 end
 
 function Sample(model::AbstractModel, sampler::AbstractSampler; kwargs...)
-    return Sample(Random.GLOBAL_RNG, model, sampler; kwargs...)
+    return Sample(Random.default_rng(), model, sampler; kwargs...)
 end
 
 """

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -5,7 +5,7 @@
 
             Random.seed!(1234)
             N = 1_000
-            chain = sample(MyModel(), MySampler(), N; sleepy=true, loggers=true)
+            chain = sample(MyModel(), MySampler(), N; loggers=true)
 
             @test length(LOGGERS) == 1
             logger = first(LOGGERS)
@@ -42,7 +42,7 @@
 
             logger = JunoProgressLogger()
             Logging.with_logger(logger) do
-                sample(MyModel(), MySampler(), N; sleepy=true, loggers=true)
+                sample(MyModel(), MySampler(), N; loggers=true)
             end
 
             @test length(LOGGERS) == 1
@@ -60,7 +60,7 @@
 
             Random.seed!(1234)
             N = 10
-            sample(MyModel(), MySampler(), N; sleepy=true, loggers=true)
+            sample(MyModel(), MySampler(), N; loggers=true)
 
             @test length(LOGGERS) == 1
             logger = first(LOGGERS)
@@ -82,7 +82,7 @@
 
             logger = Logging.ConsoleLogger(stderr, Logging.LogLevel(-1))
             Logging.with_logger(logger) do
-                sample(MyModel(), MySampler(), N; sleepy=true, loggers=true)
+                sample(MyModel(), MySampler(), N; loggers=true)
             end
 
             @test length(LOGGERS) == 1
@@ -92,7 +92,7 @@
 
         @testset "Suppress output" begin
             logs, _ = collect_test_logs(; min_level=Logging.LogLevel(-1)) do
-                sample(MyModel(), MySampler(), 100; progress=false, sleepy=true)
+                sample(MyModel(), MySampler(), 100; progress=false)
             end
             @test all(l.level > Logging.LogLevel(-1) for l in logs)
 
@@ -103,7 +103,7 @@
             @test !AbstractMCMC.PROGRESS[]
 
             logs, _ = collect_test_logs(; min_level=Logging.LogLevel(-1)) do
-                sample(MyModel(), MySampler(), 100; sleepy=true)
+                sample(MyModel(), MySampler(), 100)
             end
             @test all(l.level > Logging.LogLevel(-1) for l in logs)
 
@@ -462,8 +462,8 @@
     end
 
     @testset "Chain constructors" begin
-        chain1 = sample(MyModel(), MySampler(), 100; sleepy=true)
-        chain2 = sample(MyModel(), MySampler(), 100; sleepy=true, chain_type=MyChain)
+        chain1 = sample(MyModel(), MySampler(), 100)
+        chain2 = sample(MyModel(), MySampler(), 100; chain_type=MyChain)
 
         @test chain1 isa Vector{<:MySample}
         @test chain2 isa MyChain

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -21,7 +21,6 @@ function AbstractMCMC.step(
     model::MyModel,
     sampler::MySampler,
     state::Union{Nothing,Integer}=nothing;
-    sleepy=false,
     loggers=false,
     init_params=nothing,
     kwargs...,
@@ -34,7 +33,6 @@ function AbstractMCMC.step(
     end
 
     loggers && push!(LOGGERS, Logging.current_logger())
-    sleepy && sleep(0.001)
 
     _state = state === nothing ? 1 : state + 1
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -72,7 +72,7 @@ end
 
 # Set a default convergence function.
 function AbstractMCMC.sample(model, sampler::MySampler; kwargs...)
-    return sample(Random.GLOBAL_RNG, model, sampler, isdone; kwargs...)
+    return sample(Random.default_rng(), model, sampler, isdone; kwargs...)
 end
 
 function AbstractMCMC.chainscat(


### PR DESCRIPTION
In Julia >= 1.3, actually `Random.default_rng()` is the intended (and now also properly documented: https://github.com/JuliaLang/julia/pull/44733) way to obtain the default RNG. 