### PR TITLE
Do not test Atom/Juno

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,10 +30,9 @@ Transducers = "0.4.30"
 julia = "1.6"
 
 [extras]
-Atom = "c52e3926-4ff0-5f6e-af25-54175e0327b1"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Atom", "IJulia", "Statistics", "Test"]
+test = ["IJulia", "Statistics", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using AbstractMCMC
-using Atom.Progress: JunoProgressLogger
 using ConsoleProgressMonitor: ProgressLogger
 using IJulia
 using LogDensityProblems

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -34,22 +34,6 @@
             @test chain[1].b == 3.2
         end
 
-        @testset "Juno" begin
-            empty!(LOGGERS)
-
-            Random.seed!(1234)
-            N = 10
-
-            logger = JunoProgressLogger()
-            Logging.with_logger(logger) do
-                sample(MyModel(), MySampler(), N; loggers=true)
-            end
-
-            @test length(LOGGERS) == 1
-            @test first(LOGGERS) === logger
-            @test Logging.current_logger() === CURRENT_LOGGER
-        end
-
         @testset "IJulia" begin
             # emulate running IJulia kernel
             @eval IJulia begin


### PR DESCRIPTION
This PR removes tests of progress logging with Atom/Juno since it holds back other test dependencies: The package is in maintenance-only mode and CompatHelper PRs are not merged anymore (see https://github.com/JunoLab/Atom.jl/pulls).