### PR TITLE
Add error hint for MethodErrors on LogDensityModel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,9 @@
 name = "AbstractMCMC"
 uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
-keywords = ["markov chain monte carlo", "probablistic programming"]
+keywords = ["markov chain monte carlo", "probabilistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "5.2.0"
+version = "5.2.1"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probabilistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "5.2.1"
+version = "5.3.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -88,4 +88,19 @@ include("stepper.jl")
 include("transducer.jl")
 include("logdensityproblems.jl")
 
+function __init__()
+    if isdefined(Base.Experimental, :register_error_hint)
+        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, _
+            if Base.parentmodule(exc.f) == LogDensityProblems &&
+                any(a -> a <: LogDensityModel, argtypes)
+                printstyled(
+                    io,
+                    "\nAbstractMCMC.LogDensityModel is a wrapper and does not itself implement the LogDensityProblems.jl interface. To use LogDensityProblems.jl methods, access the inner type with (e.g.) `logdensity(model.logdensity, params)` instead of `logdensity(model, params)`.";
+                    color=:cyan,
+                )
+            end
+        end
+    end
+end
+
 end # module AbstractMCMC

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -88,15 +88,14 @@ include("stepper.jl")
 include("transducer.jl")
 include("logdensityproblems.jl")
 
-function __init__()
-    if isdefined(Base.Experimental, :register_error_hint)
+if isdefined(Base.Experimental, :register_error_hint)
+    function __init__()
         Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, _
             if Base.parentmodule(exc.f) == LogDensityProblems &&
                 any(a -> a <: LogDensityModel, argtypes)
-                printstyled(
+                print(
                     io,
-                    "\nAbstractMCMC.LogDensityModel is a wrapper and does not itself implement the LogDensityProblems.jl interface. To use LogDensityProblems.jl methods, access the inner type with (e.g.) `logdensity(model.logdensity, params)` instead of `logdensity(model, params)`.";
-                    color=:cyan,
+                    "\n`AbstractMCMC.LogDensityModel` is a wrapper and does not itself implement the LogDensityProblems.jl interface. To use LogDensityProblems.jl methods, access the inner type with (e.g.) `logdensity(model.logdensity, params)` instead of `logdensity(model, params)`.",
                 )
             end
         end

--- a/test/logdensityproblems.jl
+++ b/test/logdensityproblems.jl
@@ -22,6 +22,13 @@
         @test model.logdensity === ℓ
 
         @test_throws ArgumentError AbstractMCMC.LogDensityModel(mylogdensity)
+
+        try
+            LogDensityProblems.logdensity(model, ones(10))
+        catch exc
+            @test exc isa MethodError
+            @test occursin("is a wrapper", sprint(showerror, exc))
+        end
     end
 
     @testset "fallback for log densities" begin

--- a/test/logdensityproblems.jl
+++ b/test/logdensityproblems.jl
@@ -27,7 +27,9 @@
             LogDensityProblems.logdensity(model, ones(10))
         catch exc
             @test exc isa MethodError
-            @test occursin("is a wrapper", sprint(showerror, exc))
+            if isdefined(Base.Experimental, :register_error_hint)
+                @test occursin("is a wrapper", sprint(showerror, exc))
+            end
         end
     end
 


### PR DESCRIPTION
If a user creates their own AbstractMCMC sampler and passes it something that obeys the LogDensityProblems.jl interface, AbstractMCMC quietly wraps it in a `LogDensityModel` type which doesn't obey the same interface, which can be mildly confusing. (Well, it did catch me out, so there may be other new users out there too who bumped into it too :))

As this is a conscious decision (cf. https://github.com/TuringLang/AbstractMCMC.jl/pull/110#discussion_r1043893301) this PR makes it such that if somebody tries to call LogDensityProblems.jl methods on a LogDensityModel, they get a friendly nudge in the right direction.

MWE:

```julia
julia> using LogDensityProblems

julia> using AbstractMCMC: LogDensityModel

julia> struct MyModel end

julia> # In practice one would define more methods, but this is the only one needed for AbstractMCMC to not complain

julia> LogDensityProblems.capabilities(::Type{MyModel}) = LogDensityProblems.LogDensityOrder{0}()

julia> lm = LogDensityModel(MyModel())
LogDensityModel{MyModel}(MyModel())

julia> LogDensityProblems.logdensity(lm, 0)
ERROR: MethodError: no method matching logdensity(::LogDensityModel{MyModel}, ::Int64)
AbstractMCMC.LogDensityModel is a wrapper and does not itself implement the LogDensityProblems.jl interface. To use LogDensityProblems.jl methods, access the inner type with (e.g.) `logdensity(model.logdensity, params)` instead of `logdensity(model, params)`.
Stacktrace:
 [1] top-level scope
   @ REPL[7]:1
```