### PR TITLE
Use `copy` instead of `deepcopy` for RNGs

### DIFF
--- a/src/sample.jl
+++ b/src/sample.jl
@@ -391,7 +391,8 @@ function mcmcsample(
     nchunks = min(nchains, Threads.nthreads())
     chunksize = cld(nchains, nchunks)
     interval = 1:nchunks
-    rngs = [deepcopy(rng) for _ in interval]
+    # `copy` instead of `deepcopy` for RNGs: https://github.com/JuliaLang/julia/issues/42899
+    rngs = [copy(rng) for _ in interval]
     models = [deepcopy(model) for _ in interval]
     samplers = [deepcopy(sampler) for _ in interval]
 


### PR DESCRIPTION
My take-away from https://github.com/JuliaLang/julia/issues/42899 is that we should use `copy` instead of `deepcopy` for RNGs. More generally, based on https://github.com/JuliaLang/julia/issues/42899#issuecomment-1058487002 we might also want to use `copy` for models and samplers (possibly requires defining `copy` in a few downstream packages).