### PR TITLE
Add optional argument of `logdensity_function` to `getparams` and `setparams!!`

### DIFF
--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -81,23 +81,27 @@ The `MCMCSerial` algorithm allows users to sample serially, with no thread or pr
 struct MCMCSerial <: AbstractMCMCEnsemble end
 
 """
-    getparams(state[; kwargs...])
+    getparams(state[, logdensity_function])
 
 Retrieve the values of parameters from the sampler's `state` as a `Vector{<:Real}`.
 """
 function getparams end
 
 """
-    setparams!!(state, params)
+    setparams!!(state, params[, logdensity_function])
 
 Set the values of parameters in the sampler's `state` from a `Vector{<:Real}`. 
 
 This function should follow the `BangBang` interface: mutate `state` in-place if possible and 
 return the mutated `state`. Otherwise, it should return a new `state` containing the updated parameters.
 
-Although not enforced, it should hold that `setparams!!(state, getparams(state)) == state`. In another
-word, the sampler should implement a consistent transformation between its internal representation
+Although not enforced, it should hold that `setparams!!(state, getparams(state)) == state`. In other
+words, the sampler should implement a consistent transformation between its internal representation
 and the vector representation of the parameter values.
+
+Sometimes, to maintain the consistency of the log density and parameter values, an optional
+`logdensity_function` can be provided. This is useful for samplers that need to evaluate the
+log density at the new parameter values.
 """
 function setparams!! end
 


### PR DESCRIPTION
ref: https://github.com/TuringLang/AdvancedHMC.jl/pull/378#discussion_r1811326624