### PR TITLE
Fix pluralisation in progress message

### DIFF
--- a/src/sample.jl
+++ b/src/sample.jl
@@ -1,6 +1,8 @@
 # Default implementations of `sample`.
 const PROGRESS = Ref(true)
 
+_pluralise(n; singular="", plural="s") = n == 1 ? singular : plural
+
 """
     setprogress!(progress::Bool; silent::Bool=false)
 
@@ -372,7 +374,7 @@ function mcmcsample(
     N::Integer,
     nchains::Integer;
     progress=PROGRESS[],
-    progressname="Sampling ($(min(nchains, Threads.nthreads())) threads)",
+    progressname="Sampling ($(min(nchains, Threads.nthreads())) thread$(_pluralise(min(nchains, Threads.nthreads()))))",
     initial_params=nothing,
     initial_state=nothing,
     kwargs...,
@@ -489,7 +491,7 @@ function mcmcsample(
     N::Integer,
     nchains::Integer;
     progress=PROGRESS[],
-    progressname="Sampling ($(Distributed.nworkers()) processes)",
+    progressname="Sampling ($(Distributed.nworkers()) process$(_pluralise(Distributed.nworkers(); plural="es")))",
     initial_params=nothing,
     initial_state=nothing,
     kwargs...,


### PR DESCRIPTION
This has been bugging me way more than it should, but if you sample with 1 thread or 1 process it says `Sampling (1 threads)` or `Sampling (1 processes)`.

This fixes it.

-----

(It bugs me much less than this, though, which I get to see every time I commute into the office:)

<img width="312" alt="Screenshot 2024-11-29 at 22 10 38" src="https://github.com/user-attachments/assets/d1206eeb-b728-4ad8-bb8a-509f0400734a">

