### PR TITLE
Fix indexing for chains in different threads

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probabilistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "5.6.0"
+version = "5.6.1"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -445,7 +445,7 @@ function mcmcsample(
                             chainidx_hi = i * (m + 1)
                             nchains_chunk = m + 1
                         else
-                            chainidx_hi = n * (m + 1) + (i - n) * m
+                            chainidx_hi = i * m + n # n * (m + 1) + (i - n) * m
                             nchains_chunk = m
                         end
                         chainidx_lo = chainidx_hi - nchains_chunk + 1


### PR DESCRIPTION
Closes #153 

If there were 6 threads and 9 chains, the previous code (https://github.com/TuringLang/AbstractMCMC.jl/blob/5a3b155ed0b8b7e97810005a22e013b8b4da2bb2/src/sample.jl#L441-L445) would generate the following `chainidxs` for each thread

```
1:2
3:4
5:6
7:8
9:10
11:10
```

Somewhere later on (probably in the fifth thread with `chainidxs = 9:10`) this causes indexing errors as we only have a vector of size 9.

This PR changes it such that for the same inputs (6 threads and 9 chains) it generates the following `chainidxs`

```
1:2
3:4
5:6
7:7
8:8
9:9
```

The error in #153 is fixed

```julia
julia> samples = [sample_chains(chain_count) for chain_count in 1:30]
30-element Vector{Chains{Float64, AxisArrays.AxisArray{Float64, 3, Array{Float64, 3}, Tuple{AxisArrays.Axis{:iter, StepRange{Int64, Int64}}, AxisArrays.Axis{:var, Vector{Symbol}}, AxisArrays.Axis{:chain, UnitRange{Int64}}}}, Missing, @NamedTuple{parameters::Vector{Symbol}, internals::Vector{Symbol}}}}:
 MCMC chain (1000×14×1 Array{Float64, 3})
 MCMC chain (1000×14×2 Array{Float64, 3})
 MCMC chain (1000×14×3 Array{Float64, 3})
 MCMC chain (1000×14×4 Array{Float64, 3})
 MCMC chain (1000×14×5 Array{Float64, 3})
 MCMC chain (1000×14×6 Array{Float64, 3})
 MCMC chain (1000×14×7 Array{Float64, 3})
 MCMC chain (1000×14×8 Array{Float64, 3})
 MCMC chain (1000×14×9 Array{Float64, 3})
 MCMC chain (1000×14×10 Array{Float64, 3})
 MCMC chain (1000×14×11 Array{Float64, 3})
 MCMC chain (1000×14×12 Array{Float64, 3})
 MCMC chain (1000×14×13 Array{Float64, 3})
 MCMC chain (1000×14×14 Array{Float64, 3})
 MCMC chain (1000×14×15 Array{Float64, 3})
 MCMC chain (1000×14×16 Array{Float64, 3})
 MCMC chain (1000×14×17 Array{Float64, 3})
 MCMC chain (1000×14×18 Array{Float64, 3})
 MCMC chain (1000×14×19 Array{Float64, 3})
 MCMC chain (1000×14×20 Array{Float64, 3})
 MCMC chain (1000×14×21 Array{Float64, 3})
 MCMC chain (1000×14×22 Array{Float64, 3})
 MCMC chain (1000×14×23 Array{Float64, 3})
 MCMC chain (1000×14×24 Array{Float64, 3})
 MCMC chain (1000×14×25 Array{Float64, 3})
 MCMC chain (1000×14×26 Array{Float64, 3})
 MCMC chain (1000×14×27 Array{Float64, 3})
 MCMC chain (1000×14×28 Array{Float64, 3})
 MCMC chain (1000×14×29 Array{Float64, 3})
 MCMC chain (1000×14×30 Array{Float64, 3})

julia> println("Thread count: $(Threads.nthreads())")
Thread count: 6

julia> for i in eachindex(samples)
           isnothing(samples[i]) && println("BoundsError with $i chains")
       end
```