### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,36 +18,24 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }}
+    runs-on: ${{ matrix.runner.os }}
     strategy:
       matrix:
         version:
           - 'min'
           - '1'
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        arch:
-          - x86
-          - x64
         num_threads:
           - 1
           - 2
-        exclude:
-          - os: windows-latest
-            arch: x86
-          - os: macOS-latest
-            arch: x86
-          - version: '1.6'
-            num_threads: 2
-        include:
-          - version: '1'
-            os: ubuntu-latest
+        runner:
+          - os: ubuntu-latest
             arch: x64
-            num_threads: 1
-            coverage: true
+          - os: ubuntu-latest
+            arch: x86
+          - os: windows-latest
+            arch: x64
+          - os: macos-latest
+            arch: aarch64
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +43,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
+          arch: ${{ matrix.runner.arch }}
 
       - uses: julia-actions/cache@v2
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,16 @@ on:
       - master
   pull_request:
 
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
+# Cancel existing tests on the same PR if a new commit is added to a pull request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -13,9 +23,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.6'
+          - 'min'
           - '1'
-          - nightly
         os:
           - ubuntu-latest
           - macOS-latest
@@ -39,25 +48,31 @@ jobs:
             arch: x64
             num_threads: 1
             coverage: true
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
-        with:
-          cache-packages: "false" # caching Conda.jl causes precompilation error
+
+      - uses: julia-actions/cache@v2
+
       - uses: julia-actions/julia-buildpkg@latest
+
       - uses: julia-actions/julia-runtest@latest
         env:
           JULIA_NUM_THREADS: ${{ matrix.num_threads }}
+
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.coverage
+
       - uses: codecov/codecov-action@v1
         if: matrix.coverage
         with:
           file: lcov.info
+
       - uses: coverallsapp/github-action@master
         if: matrix.coverage
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,12 +56,12 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.coverage
 
-      - uses: codecov/codecov-action@v1
-        if: matrix.coverage
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
 
-      - uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@v2
         if: matrix.coverage
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,28 +21,36 @@ jobs:
     runs-on: ${{ matrix.runner.os }}
     strategy:
       matrix:
-        version:
-          - 'min'
-          - '1'
         num_threads:
           - 1
           - 2
         runner:
           - os: ubuntu-latest
             arch: x64
+            version: '1'
+          # x86
           - os: ubuntu-latest
             arch: x86
+            version: '1'
+          # Minimum supported version
+          - os: ubuntu-latest
+            arch: x64
+            version: 'min'
+          # Windows
           - os: windows-latest
             arch: x64
+            version: '1'
+          # macOS
           - os: macos-latest
             arch: aarch64
+            version: '1'
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: julia-actions/setup-julia@v2
         with:
-          version: ${{ matrix.version }}
+          version: ${{ matrix.runner.version }}
           arch: ${{ matrix.runner.arch }}
 
       - uses: julia-actions/cache@v2

--- a/.github/workflows/JuliaPre.yml
+++ b/.github/workflows/JuliaPre.yml
@@ -1,0 +1,25 @@
+name: JuliaPre
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: 'pre' # pre-release
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
- Bumping versions of actions

- Also changing 1.6 -> 'min' so that we don't have to update that in the future

- Also changing the 'nightly' test (brittle) to a new prerelease workflow

- Also enabling concurrency on PRs so that outdated CI runs are cancelled

This is all in line with other repos in TuringLang