### PR TITLE
Add `getadtype` function to AbstractSampler interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probabilistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "5.6.1"
+version = "5.7.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -20,14 +20,18 @@ chainsstack(c) = c
 chainsstack(c::AbstractVector{<:AbstractChains}) = reduce(chainscat, c)
 
 """
-    getadtype(sampler::AbstractSampler)
+    getadtype(s::AbstractSampler)
+    getadtype(m::AbstractModel, s::AbstractSampler)
 
-If the sampler specifies an automatic differentiation (AD) backend to use, this
-function should return the corresponding `ADTypes.AbstractADType`.
+Specify the `ADTypes.AbstractADType` to be used when sampling from model `m` using sampler `s`.
+
+If the model is not relevant, then the implementation of AbstractSampler can
+directly overload the single-argument method `getadtype(s::AbstractSampler)`.
 
 By default, this returns `nothing`.
 """
 getadtype(::AbstractSampler) = nothing
+getadtype(::AbstractModel, spl::AbstractSampler) = getadtype(spl)
 
 """
     bundle_samples(samples, model, sampler, state, chain_type[; kwargs...])

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -20,6 +20,16 @@ chainsstack(c) = c
 chainsstack(c::AbstractVector{<:AbstractChains}) = reduce(chainscat, c)
 
 """
+    getadtype(sampler::AbstractSampler)
+
+If the sampler specifies an automatic differentiation (AD) backend to use, this
+function should return the corresponding `ADTypes.AbstractADType`.
+
+By default, this returns `nothing`.
+"""
+getadtype(::AbstractSampler) = nothing
+
+"""
     bundle_samples(samples, model, sampler, state, chain_type[; kwargs...])
 
 Bundle all `samples` that were sampled from the `model` with the given `sampler` in a chain.


### PR DESCRIPTION
Right now, Turing.jl contains some pretty ad hoc code to determine the underlying AD backend for a sampler:

https://github.com/TuringLang/Turing.jl/blob/ddd74b1cf4694b66698f225db549d2cfb5eb826c/src/mcmc/Inference.jl#L181-L189

In the process, it does a bunch of type piracy and this definition also makes it hard to move any of this behaviour to DynamicPPL.

In particular, it actually means that the AD backend (inside a `LogDensityProblemsAD.ADgradient` object) is only specified by code inside Turing.jl, even though DynamicPPL should have enough information to infer the AD type from the sampler it's given.

This PR proposes to move the AD type specification to the lower layer of AbstractMCMC so that this information is accessible across more layers.

It's not 100% obvious to me that gradient-based samplers _necessarily_ need to declare their adtype (maybe depending on the sampler implementation, it might be declared elsewhere, e.g. in the model), but having `getadtype` be a property of the sampler does at least match what we currently do.

**Followups if this is merged**

- [x] Implement `getadtype(::DynamicPPL.Sampler)`
- [ ] Remove extra code from Turing
- [ ] (lower priority) Implement in AdvancedHMC