### PR TITLE
Improve error message when initial_params / initial_state has wrong length

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probabilistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "5.6.1"
+version = "5.6.2"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -653,7 +653,7 @@ tighten_eltype(x::Vector{Any}) = map(identity, x)
 
 @nospecialize check_initial_params(x, n) = throw(
     ArgumentError(
-        "initial parameters must be specified as a vector of length equal to the number of chains or `nothing`",
+        "initial_params must be specified as a vector of length equal to the number of chains or `nothing`",
     ),
 )
 check_initial_params(::Nothing, n) = nothing
@@ -661,7 +661,7 @@ function check_initial_params(x::AbstractArray, n)
     if length(x) != n
         throw(
             ArgumentError(
-                "incorrect number of initial parameters (expected $n, received $(length(x))"
+                "the length of initial_params ($(length(x))) does not equal the number of chains ($n)",
             ),
         )
     end
@@ -671,7 +671,7 @@ end
 
 @nospecialize check_initial_state(x, n) = throw(
     ArgumentError(
-        "initial states must be specified as a vector of length equal to the number of chains or `nothing`",
+        "initial_state must be specified as a vector of length equal to the number of chains or `nothing`",
     ),
 )
 check_initial_state(::Nothing, n) = nothing
@@ -679,7 +679,7 @@ function check_initial_state(x::AbstractArray, n)
     if length(x) != n
         throw(
             ArgumentError(
-                "incorrect number of initial states (expected $n, received $(length(x))"
+                "the length of initial_state ($(length(x))) does not equal the number of chains ($n)",
             ),
         )
     end


### PR DESCRIPTION
cf. https://github.com/TuringLang/Turing.jl/issues/2557

`check_initial_...` is only used when sampling multiple chains (it doesn't check the actual number of parameters in the model because AbstractMCMC has no way of knowing this), so the old error message was arguably misleading.