### PR TITLE
Prevent spurious error hints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probabilistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "5.6.2"
+version = "5.6.3"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -123,8 +123,11 @@ include("logdensityproblems.jl")
 if isdefined(Base.Experimental, :register_error_hint)
     function __init__()
         Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, _
-            if Base.parentmodule(exc.f) == LogDensityProblems &&
-                any(a -> a <: LogDensityModel, argtypes)
+            if (
+                any(a -> a <: LogDensityModel, argtypes) &&
+                exc.f isa Function &&
+                Base.parentmodule(exc.f) == LogDensityProblems
+            )
                 print(
                     io,
                     "\n`AbstractMCMC.LogDensityModel` is a wrapper and does not itself implement the LogDensityProblems.jl interface. To use LogDensityProblems.jl methods, access the inner type with (e.g.) `logdensity(model.logdensity, params)` instead of `logdensity(model, params)`.",


### PR DESCRIPTION
The error hint for `MethodError` (see https://github.com/TuringLang/AbstractMCMC.jl/pull/146) is indiscriminate in that it catches _any_ `MethodError`. We can't do much about that, but we can try to restrict it to MethodErrors which only involve one of the arguments being a `LogDensityModel`.

https://github.com/TuringLang/AbstractMCMC.jl/blob/ececa17d5c354aa3279e7ce970ac768751c22fcf/src/AbstractMCMC.jl#L123-L135

Unfortunately,  `Base.parentmodule` is not defined for _callable structs_, so if you called a callable struct with the wrong arguments _and_ you happened to have AbstractMCMC in your environment, this error hint would try to take over and would itself error. I discovered this when calling `(::DynamicPPL.Model)(args...)` with the wrong combination of arguments.

This PR fixes it by (1) reversing the order of checks, so that it shortcircuits if none of the arguments are `LogDensityModel`s; and also (2) explicitly checking that `exc.f` is a function, because the things we want to catch are `LogDensityProblems.foo` which are indeed functions. Both together might be a bit overkill, but anyway.