### PR TITLE
Progress bars when sampling multiple chains

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probabilistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "5.6.3"
+version = "5.7.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ ProgressLogging = "0.1"
 StatsBase = "0.32, 0.33, 0.34"
 TerminalLoggers = "0.1"
 Transducers = "0.4.30"
-UUIDs = "1.11.0"
+UUIDs = "<0.0.1, 1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 BangBang = "0.3.19, 0.4"
@@ -29,6 +30,7 @@ ProgressLogging = "0.1"
 StatsBase = "0.32, 0.33, 0.34"
 TerminalLoggers = "0.1"
 Transducers = "0.4.30"
+UUIDs = "1.11.0"
 julia = "1.6"
 
 [extras]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -68,7 +68,7 @@ AbstractMCMC.MCMCSerial
 ## Common keyword arguments
 
 Common keyword arguments for regular and parallel sampling are:
-- `progress` (default: `AbstractMCMC.PROGRESS[]` which is `true` initially):  toggles progress logging
+- `progress` (default: `AbstractMCMC.PROGRESS[]` which is `true` initially): toggles progress logging. See the section on [Progress logging](#progress-logging) below for more details.
 - `chain_type` (default: `Any`): determines the type of the returned chain
 - `callback` (default: `nothing`): if `callback !== nothing`, then
   `callback(rng, model, sampler, sample, iteration)` is called after every sampling step,
@@ -90,11 +90,30 @@ However, multiple packages such as [EllipticalSliceSampling.jl](https://github.c
 To ensure that sampling multiple chains "just works" when sampling of a single chain is implemented, [we decided to support `initial_params` in the default implementations of the ensemble methods](https://github.com/TuringLang/AbstractMCMC.jl/pull/94):
 - `initial_params` (default: `nothing`): if `initial_params isa AbstractArray`, then the `i`th element of `initial_params` is used as initial parameters of the `i`th chain. If one wants to use the same initial parameters `x` for every chain, one can specify e.g. `initial_params = FillArrays.Fill(x, N)`.
 
-Progress logging can be enabled and disabled globally with `AbstractMCMC.setprogress!(progress)`.
+## Progress logging
+
+The default value for the `progress` keyword argument is `AbstractMCMC.PROGRESS[]`, which is always set to `true` unless modified with `AbstractMCMC.setprogress!`.
+For example, `setprogress!(false)` will disable all progress logging.
 
 ```@docs
 AbstractMCMC.setprogress!
 ```
+
+For single-chain sampling (i.e., `sample([rng,] model, sampler, N)`), as well as multiple-chain sampling with `MCMCSerial`, the `progress` keyword argument should be a `Bool`.
+
+For multiple-chain sampling using `MCMCThreads`, there are several, more detailed, options:
+
+- `:perchain`: create one progress bar per chain being sampled
+- `:overall`: create one progress bar for the overall sampling process, which tracks the percentage of samples that have been sampled across all chains
+- `:none`: do not create any progress bar
+- `true` (the default): use `perchain` for 10 or fewer chains, and `overall` for more than 10 chains
+- `false`: same as `none`, i.e. no progress bar
+
+The threshold of 10 chains can be changed using `AbstractMCMC.setmaxchainsprogress!(N)`, which will cause `MCMCThreads` to use `:perchain` for `N` or fewer chains, and `:overall` for more than `N` chains.
+Thus, for example, if you _always_ want to use `:overall`, you can call `AbstractMCMC.setmaxchainsprogress!(0)`.
+
+Multiple-chain sampling using `MCMCDistributed` behaves the same as `MCMCThreads`, except that `:perchain` is not (yet?) implemented.
+So, `true` always corresponds to `:overall`, and `false` corresponds to `:none`.
 
 ## Chains
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -92,31 +92,44 @@ To ensure that sampling multiple chains "just works" when sampling of a single c
 
 ## Progress logging
 
-The default value for the `progress` keyword argument is `AbstractMCMC.PROGRESS[]`, which is always set to `true` unless modified with `AbstractMCMC.setprogress!`.
-For example, `setprogress!(false)` will disable all progress logging.
+Progress logging is controlled in one of two ways:
 
-```@docs
-AbstractMCMC.setprogress!
-```
+- by passing the `progress` keyword argument to the `sample(...)` function, or
+- by globally changing the defaults with `AbstractMCMC.setprogress!` and `AbstractMCMC.setmaxchainsprogress!`.
+
+### `progress` keyword argument
 
 For single-chain sampling (i.e., `sample([rng,] model, sampler, N)`), as well as multiple-chain sampling with `MCMCSerial`, the `progress` keyword argument should be a `Bool`.
 
 For multiple-chain sampling using `MCMCThreads`, there are several, more detailed, options:
 
-- `:perchain`: create one progress bar per chain being sampled
+- `:perchain`: create one progress bar per chain being sampled, plus one progress bar tracking the number of chains
 - `:overall`: create one progress bar for the overall sampling process, which tracks the percentage of samples that have been sampled across all chains
 - `:none`: do not create any progress bar
 - `true` (the default): use `perchain` for 10 or fewer chains, and `overall` for more than 10 chains
 - `false`: same as `none`, i.e. no progress bar
-
-The threshold of 10 chains can be changed using `AbstractMCMC.setmaxchainsprogress!(N)`, which will cause `MCMCThreads` to use `:perchain` for `N` or fewer chains, and `:overall` for more than `N` chains.
-Thus, for example, if you _always_ want to use `:overall`, you can call `AbstractMCMC.setmaxchainsprogress!(0)`.
 
 Multiple-chain sampling using `MCMCDistributed` behaves the same as `MCMCThreads`, except that `:perchain` is not (yet?) implemented.
 So, `true` always corresponds to `:overall`, and `false` corresponds to `:none`.
 
 !!! warning "Do not override the `progress` keyword argument"
     If you are implementing your own methods for `sample(...)`, you should make sure to not override the `progress` keyword argument if you want progress logging in multi-chain sampling to work correctly, as the multi-chain `sample()` call makes sure to specifically pass custom values of `progress` to the single-chain calls.
+
+### Global settings
+
+If you are sampling multiple times and would like to change the default behaviour, you can use these functions to control progress logging globally:
+
+```@docs
+AbstractMCMC.setprogress!
+AbstractMCMC.setmaxchainsprogress!
+```
+
+`setprogress!` is more general, and applies to all types of sampling (both single- and multiple-chain).
+It only takes a boolean argument, which switches progress logging on or off.
+For example, `setprogress!(false)` will disable all progress logging.
+
+On the other hand, `setmaxchainsprogress!` is specific to multiple-chain sampling, and allows you to set the threshold for when to switch from `:perchain` to `:overall` progress logging.
+Thus, for example, if you want to keep progress logging on but _always_ want to use `:overall`, you can set `AbstractMCMC.setmaxchainsprogress!(0)`.
 
 ## Chains
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -115,6 +115,9 @@ Thus, for example, if you _always_ want to use `:overall`, you can call `Abstrac
 Multiple-chain sampling using `MCMCDistributed` behaves the same as `MCMCThreads`, except that `:perchain` is not (yet?) implemented.
 So, `true` always corresponds to `:overall`, and `false` corresponds to `:none`.
 
+!!! warning "Do not override the `progress` keyword argument"
+    If you are implementing your own methods for `sample(...)`, you should make sure to not override the `progress` keyword argument if you want progress logging in multi-chain sampling to work correctly, as the multi-chain `sample()` call makes sure to specifically pass custom values of `progress` to the single-chain calls.
+
 ## Chains
 
 The `chain_type` keyword argument allows to set the type of the returned chain. A common

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -103,33 +103,31 @@ For single-chain sampling (i.e., `sample([rng,] model, sampler, N)`), as well as
 
 For multiple-chain sampling using `MCMCThreads`, there are several, more detailed, options:
 
-- `:perchain`: create one progress bar per chain being sampled, plus one progress bar tracking the number of chains
 - `:overall`: create one progress bar for the overall sampling process, which tracks the percentage of samples that have been sampled across all chains
+- `:perchain`: in addition to `:overall`, also create one progress bar for each individual chain
 - `:none`: do not create any progress bar
-- `true` (the default): use `perchain` for 10 or fewer chains, and `overall` for more than 10 chains
-- `false`: same as `none`, i.e. no progress bar
+- `true` (the default): same as `:overall`, i.e. one progress bar for the overall sampling process
+- `false`: same as `:none`, i.e. no progress bar
 
 Multiple-chain sampling using `MCMCDistributed` behaves the same as `MCMCThreads`, except that `:perchain` is not (yet?) implemented.
-So, `true` always corresponds to `:overall`, and `false` corresponds to `:none`.
 
 !!! warning "Do not override the `progress` keyword argument"
     If you are implementing your own methods for `sample(...)`, you should make sure to not override the `progress` keyword argument if you want progress logging in multi-chain sampling to work correctly, as the multi-chain `sample()` call makes sure to specifically pass custom values of `progress` to the single-chain calls.
 
 ### Global settings
 
-If you are sampling multiple times and would like to change the default behaviour, you can use these functions to control progress logging globally:
+If you are sampling multiple times and would like to change the default behaviour, you can use this function to control progress logging globally:
 
 ```@docs
 AbstractMCMC.setprogress!
-AbstractMCMC.setmaxchainsprogress!
 ```
 
 `setprogress!` is more general, and applies to all types of sampling (both single- and multiple-chain).
 It only takes a boolean argument, which switches progress logging on or off.
 For example, `setprogress!(false)` will disable all progress logging.
 
-On the other hand, `setmaxchainsprogress!` is specific to multiple-chain sampling, and allows you to set the threshold for when to switch from `:perchain` to `:overall` progress logging.
-Thus, for example, if you want to keep progress logging on but _always_ want to use `:overall`, you can set `AbstractMCMC.setmaxchainsprogress!(0)`.
+Note that `setprogress!` cannot be used to set the type of progress bar for multiple-chain sampling.
+If you want to use `:perchain`, it has to be set on each individual call to `sample`.
 
 ## Chains
 

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -13,6 +13,7 @@ using FillArrays: FillArrays
 using Distributed: Distributed
 using Logging: Logging
 using Random: Random
+using UUIDs: UUIDs
 
 # Reexport sample
 using StatsBase: sample

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -4,7 +4,7 @@
 macro ifwithprogresslogger(progress, exprs...)
     return esc(
         quote
-            if $progress
+            if $progress == true
                 if $hasprogresslevel($Logging.current_logger())
                     $ProgressLogging.@withprogress $(exprs...)
                 else

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -95,7 +95,7 @@ finish_progress(::ChannelProgress) = nothing
 
 # Add a custom progress logger if the current logger does not seem to be able to handle
 # progress logs.
-macro withprogresslogger(expr)
+macro maybewithricherlogger(expr)
     return esc(
         quote
             if !($hasprogresslevel($Logging.current_logger()))

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -14,25 +14,19 @@ Create a new logger for progress logging.
 struct CreateNewProgressBar{S<:AbstractString} <: AbstractProgressKwarg
     name::S
     uuid::UUIDs.UUID
-
     function CreateNewProgressBar(name::AbstractString)
-        return new{typeof{name}}(name, UUIDs.uuid4())
+        return new{typeof(name)}(name, UUIDs.uuid4())
     end
 end
 function init_progress(p::CreateNewProgressBar)
-    if hasprogresslevel(Logging.current_logger())
-        ProgressLogging.@withprogress $(exprs...)
-    else
-        $with_progresslogger($Base.@__MODULE__, $Logging.current_logger()) do
-            $ProgressLogging.@withprogress $(exprs...)
-        end
-    end
     ProgressLogging.@logprogress p.name nothing _id = p.uuid
 end
-function update_progress(p::CreateNewProgressBar, progress_frac, ::Bool)
+function update_progress(p::CreateNewProgressBar, progress_frac)
     ProgressLogging.@logprogress p.name progress_frac _id = p.uuid
 end
-finish_progress(::CreateNewProgressBar) = ProgressLogging.@logprogress "done"
+function finish_progress(p::CreateNewProgressBar)
+    ProgressLogging.@logprogress p.name "done" _id = p.uuid
+end
 
 """
     NoLogging
@@ -41,7 +35,7 @@ Do not log progress at all.
 """
 struct NoLogging <: AbstractProgressKwarg end
 init_progress(::NoLogging) = nothing
-update_progress(::NoLogging, ::Any, ::Bool) = nothing
+update_progress(::NoLogging, ::Any) = nothing
 finish_progress(::NoLogging) = nothing
 
 """
@@ -57,8 +51,21 @@ struct ExistingProgressBar{S<:AbstractString} <: AbstractProgressKwarg
     name::S
     uuid::UUIDs.UUID
 end
-init_progress(::ExistingProgressBar) = nothing
-function update_progress(p::ExistingProgressBar, progress_frac, ::Bool)
+function init_progress(p::ExistingProgressBar)
+    # Hacky code to reset the start timer if called from a multi-chain sampling
+    # process. We need this because the progress bar is constructed in the
+    # multi-chain method, i.e. if we don't do this the progress bar shows the
+    # time elapsed since _all_ sampling began, not since the current chain
+    # started.
+    try
+        bartrees = Logging.current_logger().loggers[1].logger.bartrees
+        bar = TerminalLoggers.findbar(bartrees, p.uuid).data
+        bar.tfirst = time()
+    catch
+    end
+    ProgressLogging.@logprogress p.name nothing _id = p.uuid
+end
+function update_progress(p::ExistingProgressBar, progress_frac)
     ProgressLogging.@logprogress p.name progress_frac _id = p.uuid
 end
 function finish_progress(p::ExistingProgressBar)
@@ -71,39 +78,32 @@ end
 Use a `Channel` to log progress. This is used for 'reporting' progress back
 to the main thread or worker when using `progress=:overall` with MCMCThreads or
 MCMCDistributed.
+
+n_updates is the number of updates that each child thread is expected to report
+back to the main thread.
 """
 struct ChannelProgress{T<:Union{Channel{Bool},Distributed.RemoteChannel{Channel{Bool}}}} <:
        AbstractProgressKwarg
     channel::T
+    n_updates::Int
 end
 init_progress(::ChannelProgress) = nothing
-function update_progress(p::ChannelProgress, ::Any, update_channel::Bool)
-    return update_channel && put!(p.channel, true)
-end
+update_progress(p::ChannelProgress, ::Any) = put!(p.channel, true)
 # Note: We don't want to `put!(p.channel, false)`, because that would stop the
 # channel from being used for further updates e.g. from other chains.
 finish_progress(::ChannelProgress) = nothing
 
-# avoid creating a progress bar with @withprogress if progress logging is disabled
-# and add a custom progress logger if the current logger does not seem to be able to handle
-# progress logs
-macro ifwithprogresslogger(cond, exprs...)
+# Add a custom progress logger if the current logger does not seem to be able to handle
+# progress logs.
+macro withprogresslogger(expr)
     return esc(
         quote
-            if $cond
-                # Create a new logger
-                if $hasprogresslevel($Logging.current_logger())
-                    $ProgressLogging.@withprogress $(exprs...)
-                else
-                    $with_progresslogger($Base.@__MODULE__, $Logging.current_logger()) do
-                        $ProgressLogging.@withprogress $(exprs...)
-                    end
+            if !($hasprogresslevel($Logging.current_logger()))
+                $with_progresslogger($Base.@__MODULE__, $Logging.current_logger()) do
+                    $(expr)
                 end
             else
-                # Don't create a new logger, either because progress logging
-                # was disabled, or because it's otherwise being manually
-                # managed.
-                $(exprs[end])
+                $(expr)
             end
         end,
     )

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -57,14 +57,3 @@ function with_progresslogger(f, _module, logger)
 
     return Logging.with_logger(f, LoggingExtras.TeeLogger(logger1, logger2))
 end
-
-function progresslogger()
-    # detect if code is running under IJulia since TerminalLogger does not work with IJulia
-    # https://github.com/JuliaLang/IJulia.jl#detecting-that-code-is-running-under-ijulia
-    if (Sys.iswindows() && VERSION < v"1.5.3") ||
-        (isdefined(Main, :IJulia) && Main.IJulia.inited)
-        return ConsoleProgressMonitor.ProgressLogger()
-    else
-        return TerminalLoggers.TerminalLogger()
-    end
-end

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -27,6 +27,7 @@ end
 function finish_progress!(p::CreateNewProgressBar)
     ProgressLogging.@logprogress p.name "done" _id = p.uuid
 end
+get_n_updates(::CreateNewProgressBar) = 200
 
 """
     NoLogging

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -18,13 +18,13 @@ struct CreateNewProgressBar{S<:AbstractString} <: AbstractProgressKwarg
         return new{typeof(name)}(name, UUIDs.uuid4())
     end
 end
-function init_progress(p::CreateNewProgressBar)
+function init_progress!(p::CreateNewProgressBar)
     ProgressLogging.@logprogress p.name nothing _id = p.uuid
 end
-function update_progress(p::CreateNewProgressBar, progress_frac)
+function update_progress!(p::CreateNewProgressBar, progress_frac)
     ProgressLogging.@logprogress p.name progress_frac _id = p.uuid
 end
-function finish_progress(p::CreateNewProgressBar)
+function finish_progress!(p::CreateNewProgressBar)
     ProgressLogging.@logprogress p.name "done" _id = p.uuid
 end
 
@@ -34,9 +34,9 @@ end
 Do not log progress at all.
 """
 struct NoLogging <: AbstractProgressKwarg end
-init_progress(::NoLogging) = nothing
-update_progress(::NoLogging, ::Any) = nothing
-finish_progress(::NoLogging) = nothing
+init_progress!(::NoLogging) = nothing
+update_progress!(::NoLogging, ::Any) = nothing
+finish_progress!(::NoLogging) = nothing
 
 """
     ExistingProgressBar
@@ -51,7 +51,7 @@ struct ExistingProgressBar{S<:AbstractString} <: AbstractProgressKwarg
     name::S
     uuid::UUIDs.UUID
 end
-function init_progress(p::ExistingProgressBar)
+function init_progress!(p::ExistingProgressBar)
     # Hacky code to reset the start timer if called from a multi-chain sampling
     # process. We need this because the progress bar is constructed in the
     # multi-chain method, i.e. if we don't do this the progress bar shows the
@@ -65,10 +65,10 @@ function init_progress(p::ExistingProgressBar)
     end
     ProgressLogging.@logprogress p.name nothing _id = p.uuid
 end
-function update_progress(p::ExistingProgressBar, progress_frac)
+function update_progress!(p::ExistingProgressBar, progress_frac)
     ProgressLogging.@logprogress p.name progress_frac _id = p.uuid
 end
-function finish_progress(p::ExistingProgressBar)
+function finish_progress!(p::ExistingProgressBar)
     ProgressLogging.@logprogress p.name "done" _id = p.uuid
 end
 
@@ -87,11 +87,11 @@ struct ChannelProgress{T<:Union{Channel{Bool},Distributed.RemoteChannel{Channel{
     channel::T
     n_updates::Int
 end
-init_progress(::ChannelProgress) = nothing
-update_progress(p::ChannelProgress, ::Any) = put!(p.channel, true)
+init_progress!(::ChannelProgress) = nothing
+update_progress!(p::ChannelProgress, ::Any) = put!(p.channel, true)
 # Note: We don't want to `put!(p.channel, false)`, because that would stop the
 # channel from being used for further updates e.g. from other chains.
-finish_progress(::ChannelProgress) = nothing
+finish_progress!(::ChannelProgress) = nothing
 
 # Add a custom progress logger if the current logger does not seem to be able to handle
 # progress logs.

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -23,6 +23,7 @@ function init_progress(p::CreateNewProgressBar)
 end
 function update_progress(p::CreateNewProgressBar, progress_frac)
     ProgressLogging.@logprogress p.name progress_frac _id = p.uuid
+    @show progress_frac
 end
 function finish_progress(p::CreateNewProgressBar)
     ProgressLogging.@logprogress p.name "done" _id = p.uuid

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -23,7 +23,6 @@ function init_progress(p::CreateNewProgressBar)
 end
 function update_progress(p::CreateNewProgressBar, progress_frac)
     ProgressLogging.@logprogress p.name progress_frac _id = p.uuid
-    @show progress_frac
 end
 function finish_progress(p::CreateNewProgressBar)
     ProgressLogging.@logprogress p.name "done" _id = p.uuid

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -5,8 +5,7 @@ macro ifwithprogresslogger(cond, exprs...)
     return esc(
         quote
             if $cond
-                # If progress == true, then we want to create a new logger. Note that
-                # progress might not be a Bool.
+                # Create a new logger
                 if $hasprogresslevel($Logging.current_logger())
                     $ProgressLogging.@withprogress $(exprs...)
                 else
@@ -15,8 +14,9 @@ macro ifwithprogresslogger(cond, exprs...)
                     end
                 end
             else
-                # otherwise, progress isa UUID, or a channel, or false, in
-                # which case we don't want to create a new logger.
+                # Don't create a new logger, either because progress logging
+                # was disabled, or because it's otherwise being manually
+                # managed.
                 $(exprs[end])
             end
         end,
@@ -27,8 +27,10 @@ macro log_progress_dispatch(progress, progressname, progress_frac)
     return esc(
         quote
             if $progress == true
+                # Use global logger
                 $ProgressLogging.@logprogress $progress_frac
             elseif $progress isa $UUIDs.UUID
+                # Use the logger with this specific UUID
                 $ProgressLogging.@logprogress $progressname $progress_frac _id = $progress
             else
                 # progress == false, or progress isa Channel, both of which are

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -57,3 +57,13 @@ function with_progresslogger(f, _module, logger)
 
     return Logging.with_logger(f, LoggingExtras.TeeLogger(logger1, logger2))
 end
+
+function progresslogger()
+    # detect if code is running under IJulia since TerminalLogger does not work with IJulia
+    # https://github.com/JuliaLang/IJulia.jl#detecting-that-code-is-running-under-ijulia
+    if (isdefined(Main, :IJulia) && Main.IJulia.inited)
+        return ConsoleProgressMonitor.ProgressLogger()
+    else
+        return TerminalLoggers.TerminalLogger()
+    end
+end

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -1,6 +1,5 @@
 # Default implementations of `sample`.
 const PROGRESS = Ref(true)
-const MAX_CHAINS_PROGRESS = Ref(10)
 
 _pluralise(n; singular="", plural="s") = n == 1 ? singular : plural
 
@@ -16,25 +15,6 @@ function setprogress!(progress::Bool; silent::Bool=false)
     end
     PROGRESS[] = progress
     return progress
-end
-
-"""
-    setmaxchainsprogress!(max_chains::Int, silent::Bool=false)
-
-Set the maximum number of chains to display progress bars for when sampling
-multiple chains at once (if progress logging is enabled). Above this limit, no
-progress bars are displayed for individual chains; instead, a single progress
-bar is displayed for the entire sampling process.
-"""
-function setmaxchainsprogress!(max_chains::Int, silent::Bool=false)
-    if max_chains < 0
-        throw(ArgumentError("maximum number of chains must be non-negative"))
-    end
-    if !silent
-        @info "AbstractMCMC: maximum number of per-chain progress bars set to $max_chains"
-    end
-    MAX_CHAINS_PROGRESS[] = max_chains
-    return nothing
 end
 
 function StatsBase.sample(
@@ -432,7 +412,7 @@ function mcmcsample(
 
     # Determine default progress bar style.
     if progress == true
-        progress = nchains > MAX_CHAINS_PROGRESS[] ? :overall : :perchain
+        progress = :overall
     elseif progress == false
         progress = :none
     end

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -465,9 +465,13 @@ function mcmcsample(
 
     @withprogresslogger begin
         if progress == :perchain
-            # This is the 'overall' progress bar. We create a channel for each
-            # chain to report back to when it finishes sampling.
+            # Create a channel for each chain to report back to when it
+            # finishes sampling.
             progress_channel = Channel{Bool}(nchunks)
+            # This is the 'overall' progress bar which tracks the number of
+            # chains that have completed. Note that this progress bar is backed
+            # by a channel, but it is not itself a ChannelProgress (because
+            # ChannelProgress doesn't come with a progress bar).
             overall_progress_bar = CreateNewProgressBar(progressname)
             init_progress(overall_progress_bar)
             # These are the per-chain progress bars. We generate `nchains`

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -168,7 +168,7 @@ function mcmcsample(
     start = time()
     local state
 
-    @withprogresslogger begin
+    @maybewithricherlogger begin
         init_progress(progress)
         # Determine threshold values for progress logging (by default, one
         # update per 0.5% of progress, unless this has been passed in
@@ -321,7 +321,7 @@ function mcmcsample(
     start = time()
     local state
 
-    @withprogresslogger begin
+    @maybewithricherlogger begin
         init_progress(progress)
         # Obtain the initial sample and state.
         sample, state = if num_warmup > 0
@@ -464,7 +464,7 @@ function mcmcsample(
     # Set up a chains vector.
     chains = Vector{Any}(undef, nchains)
 
-    @withprogresslogger begin
+    @maybewithricherlogger begin
         if progress == :perchain
             # Create a channel for each chain to report back to when it
             # finishes sampling.
@@ -661,7 +661,7 @@ function mcmcsample(
     pool = Distributed.CachingPool(Distributed.workers())
 
     local chains
-    @withprogresslogger begin
+    @maybewithricherlogger begin
         # Set up progress logging.
         if progress == :overall
             # Just a single progress bar for the entire sampling, but instead

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -170,10 +170,11 @@ function mcmcsample(
 
     @withprogresslogger begin
         init_progress(progress)
-        # Determine threshold values for progress logging
-        # (one update per 0.5% of progress)
+        # Determine threshold values for progress logging (by default, one
+        # update per 0.5% of progress, unless this has been passed in
+        # explicitly)
         n_updates = progress isa ChannelProgress ? progress.n_updates : 200
-        threshold = Ntotal ÷ n_updates
+        threshold = Ntotal / n_updates
         next_update = threshold
 
         # Obtain the initial sample and state.
@@ -195,7 +196,7 @@ function mcmcsample(
         itotal = 1
         if itotal >= next_update
             update_progress(progress, itotal / Ntotal)
-            next_update = itotal + threshold
+            next_update += threshold
         end
 
         # Discard initial samples.
@@ -211,7 +212,7 @@ function mcmcsample(
             itotal += 1
             if itotal >= next_update
                 update_progress(progress, itotal / Ntotal)
-                next_update = itotal + threshold
+                next_update += threshold
             end
         end
 
@@ -237,7 +238,7 @@ function mcmcsample(
                 itotal += 1
                 if itotal >= next_update
                     update_progress(progress, itotal / Ntotal)
-                    next_update = itotal + threshold
+                    next_update += threshold
                 end
             end
 
@@ -259,7 +260,7 @@ function mcmcsample(
             itotal += 1
             if itotal >= next_update
                 update_progress(progress, itotal / Ntotal)
-                next_update = itotal + threshold
+                next_update += threshold
             end
         end
         finish_progress(progress)
@@ -510,7 +511,7 @@ function mcmcsample(
                     Ntotal = progress == :overall ? nchains * updates_per_chain : nchains
                     # Determine threshold values for progress logging
                     # (one update per 0.5% of progress)
-                    threshold = Ntotal ÷ 200
+                    threshold = Ntotal / 200
                     next_update = threshold
 
                     itotal = 0
@@ -518,7 +519,7 @@ function mcmcsample(
                         itotal += 1
                         if itotal >= next_update
                             update_progress(overall_progress_bar, itotal / Ntotal)
-                            next_update = itotal + threshold
+                            next_update += threshold
                         end
                     end
                     finish_progress(overall_progress_bar)
@@ -686,7 +687,7 @@ function mcmcsample(
                     # Determine threshold values for progress logging
                     # (one update per 0.5% of progress)
                     Ntotal = nchains * updates_per_chain
-                    threshold = Ntotal ÷ 200
+                    threshold = Ntotal / 200
                     next_update = threshold
 
                     itotal = 0
@@ -694,7 +695,7 @@ function mcmcsample(
                         itotal += 1
                         if itotal >= next_update
                             update_progress(overall_progress_bar, itotal / Ntotal)
-                            next_update = itotal + threshold
+                            next_update += threshold
                         end
                     end
                     finish_progress(overall_progress_bar)

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -144,7 +144,7 @@ function mcmcsample(
     @ifwithprogresslogger progress name = progressname begin
         # Determine threshold values for progress logging
         # (one update per 0.5% of progress)
-        if progress
+        if (progress == true || progress === nothing)
             threshold = Ntotal ÷ 200
             next_update = threshold
         end
@@ -166,8 +166,12 @@ function mcmcsample(
 
         # Update the progress bar.
         itotal = 1
-        if progress && itotal >= next_update
-            ProgressLogging.@logprogress itotal / Ntotal
+        if !(progress == false) && itotal >= next_update
+            if progress == true
+                ProgressLogging.@logprogress itotal / Ntotal
+            else
+                ProgressLogging.@logprogress itotal / Ntotal _id = "hello"
+            end
             next_update = itotal + threshold
         end
 
@@ -181,8 +185,12 @@ function mcmcsample(
             end
 
             # Update the progress bar.
-            if progress && (itotal += 1) >= next_update
-                ProgressLogging.@logprogress itotal / Ntotal
+            if !(progress == false) && (itotal += 1) >= next_update
+                if progress == true
+                    ProgressLogging.@logprogress itotal / Ntotal
+                else
+                    ProgressLogging.@logprogress itotal / Ntotal _id = "hello"
+                end
                 next_update = itotal + threshold
             end
         end
@@ -206,8 +214,12 @@ function mcmcsample(
                 end
 
                 # Update progress bar.
-                if progress && (itotal += 1) >= next_update
-                    ProgressLogging.@logprogress itotal / Ntotal
+                if !(progress == false) && (itotal += 1) >= next_update
+                    if progress == true
+                        ProgressLogging.@logprogress itotal / Ntotal
+                    else
+                        ProgressLogging.@logprogress itotal / Ntotal _id = "hello"
+                    end
                     next_update = itotal + threshold
                 end
             end
@@ -227,8 +239,12 @@ function mcmcsample(
             samples = save!!(samples, sample, i, model, sampler, N; kwargs...)
 
             # Update the progress bar.
-            if progress && (itotal += 1) >= next_update
-                ProgressLogging.@logprogress itotal / Ntotal
+            if !(progress == false) && (itotal += 1) >= next_update
+                if progress == true
+                    ProgressLogging.@logprogress itotal / Ntotal
+                else
+                    ProgressLogging.@logprogress itotal / Ntotal _id = "hello"
+                end
                 next_update = itotal + threshold
             end
         end
@@ -456,12 +472,17 @@ function mcmcsample(
                             Random.seed!(_rng, seeds[chainidx])
 
                             # Sample a chain and save it to the vector.
-                            chains[chainidx] = StatsBase.sample(
+                            child_progress = if progress == false
+                                false
+                            else
+                                nothing
+                            end
+                            @ifwithprogresslogger progress chains[chainidx] = StatsBase.sample(
                                 _rng,
                                 _model,
                                 _sampler,
                                 N;
-                                progress=false,
+                                progress=child_progress,
                                 initial_params=if initial_params === nothing
                                     nothing
                                 else

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -161,7 +161,10 @@ function mcmcsample(
     start = time()
     local state
 
-    @single_ifwithprogresslogger progress name = progressname begin
+    # Only create a new progress bar if progress is explicitly equal to true, i.e.
+    # it's not a UUID (the progress bar already exists), a channel (there's no need
+    # for a new progress bar), or false (no progress bar).
+    @ifwithprogresslogger (progress == true) name = progressname begin
         # Determine threshold values for progress logging
         # (one update per 0.5% of progress)
         threshold = Ntotal ÷ 200
@@ -319,7 +322,7 @@ function mcmcsample(
     start = time()
     local state
 
-    @single_ifwithprogresslogger progress name = progressname begin
+    @ifwithprogresslogger (progress == true) name = progressname begin
         # Obtain the initial sample and state.
         sample, state = if num_warmup > 0
             if initial_state === nothing
@@ -456,7 +459,7 @@ function mcmcsample(
     # Set up a chains vector.
     chains = Vector{Any}(undef, nchains)
 
-    @multi_ifwithprogresslogger progress name = progressname begin
+    @ifwithprogresslogger (progress != :none) name = progressname begin
         if progress == :perchain
             # This is the 'overall' progress bar. We create a channel for each
             # chain to report back to when it finishes sampling.
@@ -633,7 +636,7 @@ function mcmcsample(
     pool = Distributed.CachingPool(Distributed.workers())
 
     local chains
-    @single_ifwithprogresslogger progress name = progressname begin
+    @ifwithprogresslogger (progress == true) name = progressname begin
         # Create a channel for progress logging.
         if progress
             channel = Distributed.RemoteChannel(() -> Channel{Bool}(Distributed.nworkers()))

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -454,9 +454,6 @@ function mcmcsample(
         # Start the progress bars (but in reverse order, because
         # ProgressLogging prints from the bottom up, and we want chain 1 to
         # show up at the top)
-        # TODO: This has an unintended effect that the 'time' field in the
-        # progress bar shows the total time since the beginning of sampling,
-        # even if the specific chain doesn't start sampling until later on.
         for (i, uuid) in enumerate(reverse(uuids))
             ProgressLogging.@logprogress name = "Chain $(nchains-i+1)/$nchains" nothing _id =
                 uuid
@@ -536,8 +533,13 @@ function mcmcsample(
                         end
                     end
                 finally
-                    # Stop updating the progress bar.
+                    # Stop updating the progress bars (either if sampling is done, or if
+                    # an error occurs).
                     progress && put!(channel, false)
+                    for (i, uuid) in enumerate(reverse(uuids))
+                        ProgressLogging.@logprogress name = "Chain $(nchains-i+1)/$nchains" "done" _id =
+                            uuid
+                    end
                 end
             end
         end

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -169,7 +169,7 @@ function mcmcsample(
     local state
 
     @maybewithricherlogger begin
-        init_progress(progress)
+        init_progress!(progress)
         # Determine threshold values for progress logging (by default, one
         # update per 0.5% of progress, unless this has been passed in
         # explicitly)
@@ -195,7 +195,7 @@ function mcmcsample(
         # Start the progress bar.
         itotal = 1
         if itotal >= next_update
-            update_progress(progress, itotal / Ntotal)
+            update_progress!(progress, itotal / Ntotal)
             next_update += threshold
         end
 
@@ -211,7 +211,7 @@ function mcmcsample(
             # Update the progress bar.
             itotal += 1
             if itotal >= next_update
-                update_progress(progress, itotal / Ntotal)
+                update_progress!(progress, itotal / Ntotal)
                 next_update += threshold
             end
         end
@@ -237,7 +237,7 @@ function mcmcsample(
                 # Update progress bar.
                 itotal += 1
                 if itotal >= next_update
-                    update_progress(progress, itotal / Ntotal)
+                    update_progress!(progress, itotal / Ntotal)
                     next_update += threshold
                 end
             end
@@ -259,11 +259,11 @@ function mcmcsample(
             # Update the progress bar.
             itotal += 1
             if itotal >= next_update
-                update_progress(progress, itotal / Ntotal)
+                update_progress!(progress, itotal / Ntotal)
                 next_update += threshold
             end
         end
-        finish_progress(progress)
+        finish_progress!(progress)
     end
 
     # Get the sample stop time.
@@ -322,7 +322,7 @@ function mcmcsample(
     local state
 
     @maybewithricherlogger begin
-        init_progress(progress)
+        init_progress!(progress)
         # Obtain the initial sample and state.
         sample, state = if num_warmup > 0
             if initial_state === nothing
@@ -385,7 +385,7 @@ function mcmcsample(
             # Increment iteration counter.
             i += 1
         end
-        finish_progress(progress)
+        finish_progress!(progress)
     end
 
     # Get the sample stop time.
@@ -474,7 +474,7 @@ function mcmcsample(
             # by a channel, but it is not itself a ChannelProgress (because
             # ChannelProgress doesn't come with a progress bar).
             overall_progress_bar = CreateNewProgressBar(progressname)
-            init_progress(overall_progress_bar)
+            init_progress!(overall_progress_bar)
             # These are the per-chain progress bars. We generate `nchains`
             # independent UUIDs for each progress bar
             child_progresses = [
@@ -484,7 +484,7 @@ function mcmcsample(
             # ProgressLogging prints from the bottom up, and we want chain 1 to
             # show up at the top)
             for child_progress in reverse(child_progresses)
-                init_progress(child_progress)
+                init_progress!(child_progress)
             end
             updates_per_chain = nothing
         elseif progress == :overall
@@ -518,11 +518,11 @@ function mcmcsample(
                     while take!(progress_channel)
                         itotal += 1
                         if itotal >= next_update
-                            update_progress(overall_progress_bar, itotal / Ntotal)
+                            update_progress!(overall_progress_bar, itotal / Ntotal)
                             next_update += threshold
                         end
                     end
-                    finish_progress(overall_progress_bar)
+                    finish_progress!(overall_progress_bar)
                 end
             end
 
@@ -578,7 +578,7 @@ function mcmcsample(
                                 # Tell the 'main' progress bar that this chain is done.
                                 put!(progress_channel, true)
                                 # Conclude the per-chain progress bar.
-                                finish_progress(child_progresses[chainidx])
+                                finish_progress!(child_progresses[chainidx])
                             end
                             # Note that if progress == :overall, we don't need to do anything
                             # because progress on that bar is triggered by
@@ -593,7 +593,7 @@ function mcmcsample(
                         put!(progress_channel, false)
                         # Additionally stop the per-chain progress bars
                         for child_progress in child_progresses
-                            finish_progress(child_progress)
+                            finish_progress!(child_progress)
                         end
                     elseif progress == :overall
                         # Stop updating the main progress bar (either if sampling
@@ -670,7 +670,7 @@ function mcmcsample(
             chan = Channel{Bool}(Distributed.nworkers())
             progress_channel = Distributed.RemoteChannel(() -> chan)
             overall_progress_bar = CreateNewProgressBar(progressname)
-            init_progress(overall_progress_bar)
+            init_progress!(overall_progress_bar)
             # See MCMCThreads method for the rationale behind updates_per_chain.
             updates_per_chain = max(1, 400 ÷ nchains)
             child_progresses = [
@@ -694,11 +694,11 @@ function mcmcsample(
                     while take!(progress_channel)
                         itotal += 1
                         if itotal >= next_update
-                            update_progress(overall_progress_bar, itotal / Ntotal)
+                            update_progress!(overall_progress_bar, itotal / Ntotal)
                             next_update += threshold
                         end
                     end
-                    finish_progress(overall_progress_bar)
+                    finish_progress!(overall_progress_bar)
                 end
             end
 

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -304,7 +304,7 @@ function mcmcsample(
     sampler::AbstractSampler,
     isdone;
     chain_type::Type=Any,
-    progress=PROGRESS[],
+    progress::Bool=PROGRESS[],
     progressname="Convergence sampling",
     callback=nothing,
     num_warmup=0,
@@ -328,7 +328,7 @@ function mcmcsample(
     start = time()
     local state
 
-    @ifwithprogresslogger (progress == true) name = progressname begin
+    @ifwithprogresslogger progress name = progressname begin
         # Obtain the initial sample and state.
         sample, state = if num_warmup > 0
             if initial_state === nothing

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -1,5 +1,6 @@
 # Default implementations of `sample`.
 const PROGRESS = Ref(true)
+const MAX_CHAINS_PROGRESS = Ref(10)
 
 _pluralise(n; singular="", plural="s") = n == 1 ? singular : plural
 
@@ -15,6 +16,25 @@ function setprogress!(progress::Bool; silent::Bool=false)
     end
     PROGRESS[] = progress
     return progress
+end
+
+"""
+    setmaxchainsprogress!(max_chains::Int, silent::Bool=false)
+
+Set the maximum number of chains to display progress bars for when sampling
+multiple chains at once (if progress logging is enabled). Above this limit, no
+progress bars are displayed for individual chains; instead, a single progress
+bar is displayed for the entire sampling process.
+"""
+function setmaxchainsprogress!(max_chains::Int, silent::Bool=false)
+    if max_chains < 0
+        throw(ArgumentError("maximum number of chains must be non-negative"))
+    end
+    if !silent
+        @info "AbstractMCMC: maximum number of per-chain progress bars set to $max_chains"
+    end
+    MAX_CHAINS_PROGRESS[] = max_chains
+    return nothing
 end
 
 function StatsBase.sample(
@@ -408,7 +428,7 @@ function mcmcsample(
 
     # Determine default progress bar style.
     if progress == true
-        progress = nchains > 10 ? :overall : :perchain
+        progress = nchains > MAX_CHAINS_PROGRESS[] ? :overall : :perchain
     elseif progress == false
         progress = :none
     end

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -488,7 +488,7 @@ function mcmcsample(
             # Just a single progress bar for the entire sampling, but instead
             # of tracking each chain as it comes in, we track each sample as it
             # comes in. This allows us to have more granular progress updates.
-            progress_channel = Channel{Bool}()
+            progress_channel = Channel{Bool}(nchains)
         end
 
         Distributed.@sync begin

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -153,6 +153,7 @@ function mcmcsample(
 
         # Ugly hacky code to reset the start timer if called from a multi-chain
         # sampling process
+        # TODO: How to make this better?
         if progress isa ProgressLogging.Progress
             try
                 bartrees = Logging.current_logger().loggers[1].logger.bartrees

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -158,7 +158,6 @@ function mcmcsample(
     elseif progress === false
         progress = NoLogging()
     end
-    init_progress(progress)
 
     # Determine how many samples to drop from `num_warmup` and the
     # main sampling process before we start saving samples.
@@ -170,6 +169,7 @@ function mcmcsample(
     local state
 
     @withprogresslogger begin
+        init_progress(progress)
         # Determine threshold values for progress logging
         # (one update per 0.5% of progress)
         n_updates = progress isa ChannelProgress ? progress.n_updates : 200
@@ -310,7 +310,6 @@ function mcmcsample(
     elseif progress === false
         progress = NoLogging()
     end
-    init_progress(progress)
 
     # Determine how many samples to drop from `num_warmup` and the
     # main sampling process before we start saving samples.
@@ -322,6 +321,7 @@ function mcmcsample(
     local state
 
     @withprogresslogger begin
+        init_progress(progress)
         # Obtain the initial sample and state.
         sample, state = if num_warmup > 0
             if initial_state === nothing
@@ -384,10 +384,10 @@ function mcmcsample(
             # Increment iteration counter.
             i += 1
         end
+        finish_progress(progress)
     end
 
     # Get the sample stop time.
-    finish_progress(progress)
     stop = time()
     duration = stop - start
     stats = SamplingStats(start, stop, duration)

--- a/test/sample.jl
+++ b/test/sample.jl
@@ -10,8 +10,7 @@
             @test length(LOGGERS) == 1
             logger = first(LOGGERS)
             @test logger isa TeeLogger
-            @test logger.loggers[1].logger isa
-                (Sys.iswindows() && VERSION < v"1.5.3" ? ProgressLogger : TerminalLogger)
+            @test logger.loggers[1].logger isa TerminalLogger
             @test logger.loggers[2].logger === CURRENT_LOGGER
             @test Logging.current_logger() === CURRENT_LOGGER
 


### PR DESCRIPTION
## Summary

This PR introduces more informative progress bars with `MCMCThreads` which can be configured by the user (see options below).

In today's meeting it was generally agreed that having one progress bar per chain was more informative / useful, and that an upper bound could be placed to disable that by default if there were more than `MAX_CHAINS_PROGRESS` chains.

This PR sets `MAX_CHAINS_PROGRESS = 10`. The user can override the default on a case-by-case basis using the `Symbol` versions of `progress`, or can globally set the threshold using `setmaxchainsprogress!(N)`.

For `MCMCSerial` no change is made (it already had one progress bar per chain).

For `MCMCDistributed`, `progress = :overall` is implemented (`progress = true` is a synonym for that) but `progress = :perchain` isn't, not for any good technical reason, but because it was just too much of a faff. I think that in principle it's possible to implement it similarly to how it's done for MCMCThreads (i.e., generate one UUID per chain), but I think each chain has to communicate back to the parent worker using a `RemoteChannel`, and there needs to be a way of disentangling the inputs from different chains (so you either need N `RemoteChannel`s or the channel needs to take a chain ID). I suppose if somebody really, really wants it I could do it, but given that `:overall` already works I am hoping nobody will complain.

In a technical sense this is accomplished by passing richer objects in the `progress` keyword argument (see `src/logging.jl`). This does mean that people should not override `progress` in their own implementations (I have added a warning in the docs) but it is IMO better than using callbacks.

The videos below demonstrate the behaviour for `MCMCThreads`.

Closes #82
Closes https://github.com/TuringLang/Turing.jl/issues/2264

## Setup

```julia
using AbstractMCMC
struct M <: AbstractMCMC.AbstractModel end
struct S <: AbstractMCMC.AbstractSampler end
function AbstractMCMC.step(rng, ::M, ::S, state=nothing; kwargs...)
    sleep(0.001)
    rand(rng), nothing
end
```

## `progress=:perchain`

```julia
# One progress bar per chain, plus one overall progress bar which tracks number of chains
sample(M(), S(), MCMCThreads(), 500, 6; progress=:perchain)
```

https://github.com/user-attachments/assets/970709bc-03d8-4f55-91c3-83165f633c29

## `progress=:overall`

```julia
# One overall progress bar which tracks the number of samples
sample(M(), S(), MCMCThreads(), 500, 6; progress=:perchain)
```

https://github.com/user-attachments/assets/95e4ac65-81b3-40e5-9df0-29b335f4928b

## `progress=true`

```julia
# Uses :perchain for 10 or fewer chains, :overall for more than 10 chains
# This is still the default option
sample(M(), S(), MCMCThreads(), 500, 6; progress=true)
sample(M(), S(), MCMCThreads(), 200, 11; progress=true)
```

https://github.com/user-attachments/assets/82e72c4f-c4a8-4d76-b73f-ea669e7437fc

## `progress=false` or `progress=:none`

```julia
# No progress bars at all
# `progress=:none` also works. We have to preserve the boolean values though so that
# `setprogress!(false)` works globally
sample(M(), S(), MCMCThreads(), 500, 6; progress=false)
```

https://github.com/user-attachments/assets/8fabad64-68d8-41c1-8765-fff4e159283f

## Bonus: `:perchain` and `:overall` on Pluto (it's pretty)

https://github.com/user-attachments/assets/e215736d-f5d6-45c9-b230-fc627028c6e6


## Bonus: `:perchain` in iJulia (in VSCode; it's *not* pretty)

https://github.com/user-attachments/assets/00e9d54d-6f02-4dab-9b99-e4afd81da573

## Bonus: `:overall` in iJulia (works fine)

https://github.com/user-attachments/assets/00e98f73-8bd9-4ab0-a3e7-9f8720093676

