### PR TITLE
Remove FillArrays dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ AbstractMCMCTensorBoardLoggerExt = "TensorBoardLogger"
 [compat]
 BangBang = "0.3.19, 0.4"
 ConsoleProgressMonitor = "0.1"
+FillArrays = "1"
 IJulia = "1"
 LogDensityProblems = "2"
 LoggingExtras = "0.4, 0.5, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -3,14 +3,13 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probabilistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "5.15.0"
+version = "5.15.1"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 ConsoleProgressMonitor = "88cd18e8-d9cc-4ea6-8889-5259c0d15c8b"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
@@ -31,7 +30,6 @@ AbstractMCMCTensorBoardLoggerExt = "TensorBoardLogger"
 [compat]
 BangBang = "0.3.19, 0.4"
 ConsoleProgressMonitor = "0.1"
-FillArrays = "1"
 IJulia = "1"
 LogDensityProblems = "2"
 LoggingExtras = "0.4, 0.5, 1"

--- a/src/AbstractMCMC.jl
+++ b/src/AbstractMCMC.jl
@@ -7,7 +7,6 @@ using LoggingExtras: LoggingExtras
 using ProgressLogging: ProgressLogging
 using StatsBase: StatsBase
 using TerminalLoggers: TerminalLoggers
-using FillArrays: FillArrays
 
 using Distributed: Distributed
 using Logging: Logging

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -754,10 +754,8 @@ function mcmcsample(
     check_initial_params(initial_params, nchains)
     check_initial_state(initial_state, nchains)
 
-    _initial_params =
-        initial_params === nothing ? FillArrays.Fill(nothing, nchains) : initial_params
-    _initial_state =
-        initial_state === nothing ? FillArrays.Fill(nothing, nchains) : initial_state
+    _initial_params = initial_params === nothing ? fill(nothing, nchains) : initial_params
+    _initial_state = initial_state === nothing ? fill(nothing, nchains) : initial_state
 
     # Create a seed for each chain using the provided random number generator.
     seeds = rand(rng, UInt, nchains)
@@ -880,10 +878,8 @@ function mcmcsample(
     check_initial_params(initial_params, nchains)
     check_initial_state(initial_state, nchains)
 
-    _initial_params =
-        initial_params === nothing ? FillArrays.Fill(nothing, nchains) : initial_params
-    _initial_state =
-        initial_state === nothing ? FillArrays.Fill(nothing, nchains) : initial_state
+    _initial_params = initial_params === nothing ? fill(nothing, nchains) : initial_params
+    _initial_state = initial_state === nothing ? fill(nothing, nchains) : initial_state
 
     # Create a seed for each chain using the provided random number generator.
     seeds = rand(rng, UInt, nchains)


### PR DESCRIPTION
Closes #131. The only place where `Fill` was being used was `Fill(nothing, nchains)`, and given that `fill(nothing, N)` really takes up no space, I don't think it's necessary to micro-optimise it away, so the dep can be removed.

`FillArrays` is still a test dep. Although I find this to also be quite needless, I don't see any harm in keeping it, so it stays.