### PR TITLE
Allow structured parameter containers in ParamsWithStats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 keywords = ["markov chain monte carlo", "probabilistic programming"]
 license = "MIT"
 desc = "A lightweight interface for common MCMC methods."
-version = "5.15.1"
+version = "5.16.0"
 
 [deps]
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"

--- a/docs/src/callbacks.md
+++ b/docs/src/callbacks.md
@@ -258,11 +258,12 @@ The default `ParamsWithStats` extraction constructors normalize common inputs to
 
 Packages with a structured parameter representation can also construct
 `ParamsWithStats(params, stats)` directly. The parameter container must implement `pairs`
-and `isempty`; for `==`, `isequal`, and `hash` of the wrapper to be meaningful it should
-implement those as well, and its keys should have a meaningful `string` form so name-based
-filtering and logging work. The two-argument constructor uses an empty `NamedTuple` for
-`extras`. Note the normalization above applies to `AbstractVector` subtypes: a vector-like
-container is converted to a `Symbol`-keyed `NamedTuple` rather than stored as given.
+and `isempty`; this is not validated at construction (some Base types already define those
+methods and will not fail later). Keys should have a meaningful `string` form so
+name-based filtering and logging work. The two-argument constructor uses an empty
+`NamedTuple` for `extras`. Note the normalization above applies to `AbstractVector`
+subtypes: a vector-like container is converted to a `Symbol`-keyed `NamedTuple` rather
+than stored as given.
 
 !!! warning "Mixed key types"
     Because the parameter container's keys need not be `Symbol`s, `Base.pairs(pws)` may

--- a/docs/src/callbacks.md
+++ b/docs/src/callbacks.md
@@ -258,8 +258,18 @@ The default `ParamsWithStats` extraction constructors normalize common inputs to
 
 Packages with a structured parameter representation can also construct
 `ParamsWithStats(params, stats)` directly. The parameter container must implement `pairs`
-and `isempty`; its keys do not need to be symbols. The two-argument constructor uses an
-empty `NamedTuple` for `extras`.
+and `isempty`; for `==`, `isequal`, and `hash` of the wrapper to be meaningful it should
+implement those as well, and its keys should have a meaningful `string` form so name-based
+filtering and logging work. The two-argument constructor uses an empty `NamedTuple` for
+`extras`. Note the normalization above applies to `AbstractVector` subtypes: a vector-like
+container is converted to a `Symbol`-keyed `NamedTuple` rather than stored as given.
+
+!!! warning "Mixed key types"
+    Because the parameter container's keys need not be `Symbol`s, `Base.pairs(pws)` may
+    yield pairs with mixed key types (e.g., `VarName` keys from the parameters and
+    `Symbol` keys from the statistics). Consumers should iterate the pairs generically
+    (e.g., stringify keys) and must not assume `Symbol` keys, a concrete element type, or
+    that the pairs can be collected into a `NamedTuple`.
 
 !!! note "stats vs extras"
     Use `stats` for values that change once per MCMC iteration (e.g., log probability, acceptance rate).

--- a/docs/src/callbacks.md
+++ b/docs/src/callbacks.md
@@ -250,10 +250,16 @@ function AbstractMCMC.getstats(state::MyState)
 end
 ```
 
-The `ParamsWithStats` constructors normalize all inputs to `NamedTuple`:
+The default `ParamsWithStats` extraction constructors normalize common inputs to
+`NamedTuple`:
 - `Vector{<:Real}` gets default `θ[i]` names
 - `Vector{Pair}` is converted to `NamedTuple` with the provided names
 - `NamedTuple` is used directly
+
+Packages with a structured parameter representation can also construct
+`ParamsWithStats(params, stats)` directly. The parameter container must implement `pairs`
+and `isempty`; its keys do not need to be symbols. The two-argument constructor uses an
+empty `NamedTuple` for `extras`.
 
 !!! note "stats vs extras"
     Use `stats` for values that change once per MCMC iteration (e.g., log probability, acceptance rate).

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -118,9 +118,20 @@ end
 """
     ParamsWithStats{P,S,E}
 
-A container for MCMC parameters, statistics, and extras. The parameter container can be any
-type implementing `pairs` and `isempty`; statistics and extras are stored as `NamedTuple`s.
-Use `Base.pairs(pws)` to iterate over all `(name, value)` pairs.
+A container for MCMC parameters, statistics, and extras. The parameter container can be a
+structured type; statistics and extras are stored as `NamedTuple`s. Use `Base.pairs(pws)`
+to iterate over all `(name, value)` pairs.
+
+The parameter container must implement `pairs` and `isempty`. For `==`, `isequal`, and
+`hash` of `ParamsWithStats` to be meaningful it must also implement those (with `==`
+returning `Bool` or `missing`), and its keys should have a meaningful `string` form so
+that name-based filtering and logging callbacks work. Keys are not required to be
+`Symbol`s, so `pairs(pws)` may yield pairs with mixed key types; consumers should not
+assume `Symbol` keys or a concrete element type.
+
+Note that `AbstractVector{<:Real}` and `AbstractVector{<:Pair}` parameter inputs are not
+stored as given: the extraction constructors normalize them to `Symbol`-keyed
+`NamedTuple`s (see the constructor docs below).
 
 # Fields
 - `params::P`: Parameter values in a container implementing `pairs` and `isempty`

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -118,13 +118,12 @@ end
 """
     ParamsWithStats{P,S,E}
 
-A container for MCMC parameters, statistics, and extras.
-
-All fields are stored as `NamedTuple`s to ensure a tight, well-defined interface.
-Use `Base.pairs(pws)` to iterate over `(name, value)` pairs.
+A container for MCMC parameters, statistics, and extras. The parameter container can be any
+type implementing `pairs` and `isempty`; statistics and extras are stored as `NamedTuple`s.
+Use `Base.pairs(pws)` to iterate over all `(name, value)` pairs.
 
 # Fields
-- `params::P`: Parameter values as a NamedTuple
+- `params::P`: Parameter values in a container implementing `pairs` and `isempty`
 - `stats::S`: Statistics as a NamedTuple (e.g., `(lp=...,)`)
 - `extras::E`: Extra diagnostics as a NamedTuple
 
@@ -139,10 +138,19 @@ end
 pws2 = ParamsWithStats(pws; params=true, stats=false)
 ```
 """
-struct ParamsWithStats{P<:NamedTuple,S<:NamedTuple,E<:NamedTuple}
+struct ParamsWithStats{P,S<:NamedTuple,E<:NamedTuple}
     params::P
     stats::S
     extras::E
+end
+
+"""
+    ParamsWithStats(params, stats::NamedTuple)
+
+Construct a `ParamsWithStats` with no extra diagnostics.
+"""
+function ParamsWithStats(params, stats::NamedTuple)
+    return ParamsWithStats(params, stats, NamedTuple())
 end
 
 # Constructor from Vector{<:Real} - adds default θ[i] names
@@ -235,6 +243,21 @@ end
 
 function Base.isempty(pws::ParamsWithStats)
     return (isempty(pws.params) && isempty(pws.stats) && isempty(pws.extras))
+end
+
+function Base.:(==)(pws1::ParamsWithStats, pws2::ParamsWithStats)
+    return (pws1.params == pws2.params) & (pws1.stats == pws2.stats) &
+           (pws1.extras == pws2.extras)
+end
+
+function Base.isequal(pws1::ParamsWithStats, pws2::ParamsWithStats)
+    return isequal(pws1.params, pws2.params) &&
+           isequal(pws1.stats, pws2.stats) &&
+           isequal(pws1.extras, pws2.extras)
+end
+
+function Base.hash(pws::ParamsWithStats, h::UInt)
+    return hash(pws.extras, hash(pws.stats, hash(pws.params, hash(:ParamsWithStats, h))))
 end
 
 #################################

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -257,7 +257,8 @@ function Base.isempty(pws::ParamsWithStats)
 end
 
 function Base.:(==)(pws1::ParamsWithStats, pws2::ParamsWithStats)
-    return (pws1.params == pws2.params) & (pws1.stats == pws2.stats) &
+    return (pws1.params == pws2.params) &
+           (pws1.stats == pws2.stats) &
            (pws1.extras == pws2.extras)
 end
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -122,12 +122,11 @@ A container for MCMC parameters, statistics, and extras. The parameter container
 structured type; statistics and extras are stored as `NamedTuple`s. Use `Base.pairs(pws)`
 to iterate over all `(name, value)` pairs.
 
-The parameter container must implement `pairs` and `isempty`. For `==`, `isequal`, and
-`hash` of `ParamsWithStats` to be meaningful it must also implement those (with `==`
-returning `Bool` or `missing`), and its keys should have a meaningful `string` form so
-that name-based filtering and logging callbacks work. Keys are not required to be
-`Symbol`s, so `pairs(pws)` may yield pairs with mixed key types; consumers should not
-assume `Symbol` keys or a concrete element type.
+The parameter container must implement `pairs` and `isempty`. This is not validated at
+construction; some Base types already define those methods and will not fail later. Keys
+should have a meaningful `string` form so that name-based filtering and logging callbacks
+work. Keys are not required to be `Symbol`s, so `pairs(pws)` may yield pairs with mixed
+key types; consumers should not assume `Symbol` keys or a concrete element type.
 
 Note that `AbstractVector{<:Real}` and `AbstractVector{<:Pair}` parameter inputs are not
 stored as given: the extraction constructors normalize them to `Symbol`-keyed
@@ -241,6 +240,10 @@ end
 
 Return an iterator of `(name, value)` pairs for all selected data in `pws`.
 
+Parameter keys need not be `Symbol`s, so the iterator may yield mixed key types (e.g.
+structured parameter keys together with `Symbol` keys from `stats`/`extras`). Consumers
+should iterate generically and must not assume `Symbol` keys or a concrete element type.
+
 This is the canonical way to iterate over a `ParamsWithStats`:
 ```julia
 for (name, value) in Base.pairs(pws)
@@ -254,22 +257,6 @@ end
 
 function Base.isempty(pws::ParamsWithStats)
     return (isempty(pws.params) && isempty(pws.stats) && isempty(pws.extras))
-end
-
-function Base.:(==)(pws1::ParamsWithStats, pws2::ParamsWithStats)
-    return (pws1.params == pws2.params) &
-           (pws1.stats == pws2.stats) &
-           (pws1.extras == pws2.extras)
-end
-
-function Base.isequal(pws1::ParamsWithStats, pws2::ParamsWithStats)
-    return isequal(pws1.params, pws2.params) &&
-           isequal(pws1.stats, pws2.stats) &&
-           isequal(pws1.extras, pws2.extras)
-end
-
-function Base.hash(pws::ParamsWithStats, h::UInt)
-    return hash(pws.extras, hash(pws.stats, hash(pws.params, hash(:ParamsWithStats, h))))
 end
 
 #################################

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -166,6 +166,15 @@ end
 ### ParamsWithStats   ###
 #########################
 
+struct CustomParams{T}
+    data::T
+end
+Base.pairs(params::CustomParams) = pairs(params.data)
+Base.isempty(params::CustomParams) = isempty(params.data)
+Base.:(==)(a::CustomParams, b::CustomParams) = a.data == b.data
+Base.isequal(a::CustomParams, b::CustomParams) = isequal(a.data, b.data)
+Base.hash(params::CustomParams, h::UInt) = hash(params.data, h)
+
 @testset "ParamsWithStats" begin
     @testset "Constructor from NamedTuple" begin
         pws = AbstractMCMC.ParamsWithStats((a=1.0, b=2.0), (lp=-10.0,), NamedTuple())
@@ -178,6 +187,11 @@ end
     @testset "Constructor from Vector{Real} - default names" begin
         pws = AbstractMCMC.ParamsWithStats([1.0, 2.0, 3.0], NamedTuple(), NamedTuple())
         @test pws.params == (var"θ[1]"=1.0, var"θ[2]"=2.0, var"θ[3]"=3.0)
+
+        pws_without_extras = AbstractMCMC.ParamsWithStats([1.0, 2.0], (lp=-1.0,))
+        @test pws_without_extras.params == (var"θ[1]"=1.0, var"θ[2]"=2.0)
+        @test pws_without_extras.stats == (lp=-1.0,)
+        @test isempty(pws_without_extras.extras)
     end
 
     @testset "Constructor from Vector{Pair} - named" begin
@@ -185,6 +199,19 @@ end
             ["μ" => 1.0, "σ" => 2.0], NamedTuple(), NamedTuple()
         )
         @test pws.params == (μ=1.0, σ=2.0)
+    end
+
+    @testset "Constructor from custom parameter container" begin
+        params = CustomParams((x=[1.0, 2.0], y=3.0))
+        pws = AbstractMCMC.ParamsWithStats(params, (lp=-10.0,))
+        @test pws.params === params
+        @test pws.stats == (lp=-10.0,)
+        @test pws.extras == NamedTuple()
+        @test collect(pairs(pws)) == [:x => [1.0, 2.0], :y => 3.0, :lp => -10.0]
+        @test !isempty(pws)
+
+        empty_pws = AbstractMCMC.ParamsWithStats(CustomParams(NamedTuple()), NamedTuple())
+        @test isempty(empty_pws)
     end
 
     @testset "Constructor from state" begin
@@ -210,6 +237,11 @@ end
         pws_stats = AbstractMCMC.ParamsWithStats(pws; params=false, stats=true)
         @test pws_stats.params == NamedTuple()
         @test pws_stats.stats == (lp=-10.0,)
+
+        custom_params = CustomParams((x=1.0,))
+        custom_pws = AbstractMCMC.ParamsWithStats(custom_params, NamedTuple())
+        @test AbstractMCMC.ParamsWithStats(custom_pws; stats=false).params === custom_params
+        @test AbstractMCMC.ParamsWithStats(custom_pws; params=false).params == NamedTuple()
     end
 
     @testset "Base.pairs iteration" begin
@@ -230,11 +262,24 @@ end
     end
 
     @testset "Illegal states are unrepresentable" begin
-        # Should not be able to construct with arbitrary types
+        # Statistics and extras must be NamedTuples.
         @test_throws MethodError AbstractMCMC.ParamsWithStats(1, 2, 3)
-        @test_throws MethodError AbstractMCMC.ParamsWithStats(
-            "bad", NamedTuple(), NamedTuple()
+        @test_throws MethodError AbstractMCMC.ParamsWithStats("params", 2, NamedTuple())
+        @test_throws MethodError AbstractMCMC.ParamsWithStats("params", NamedTuple(), 3)
+    end
+
+    @testset "Equality" begin
+        pws1 = AbstractMCMC.ParamsWithStats(
+            CustomParams((x=[1.0, NaN],)), (lp=-10.0,), (step_size=0.1,)
         )
+        pws2 = AbstractMCMC.ParamsWithStats(
+            CustomParams((x=[1.0, NaN],)), (lp=-10.0,), (step_size=0.1,)
+        )
+        @test isequal(pws1, pws2)
+        @test hash(pws1) == hash(pws2)
+        @test !(pws1 == pws2)
+        @test pws1 !=
+            AbstractMCMC.ParamsWithStats(pws1.params, pws1.stats, (step_size=0.2,))
     end
 end
 

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -166,14 +166,19 @@ end
 ### ParamsWithStats   ###
 #########################
 
-struct CustomParams{T}
-    data::T
+# StructuredKey: non-Symbol key with string form (VarName stand-in). StructuredParams
+# wraps a Vector of Pairs so AbstractVector{<:Pair} normalization does not kick in.
+struct StructuredKey
+    name::String
 end
-Base.pairs(params::CustomParams) = pairs(params.data)
-Base.isempty(params::CustomParams) = isempty(params.data)
-Base.:(==)(a::CustomParams, b::CustomParams) = a.data == b.data
-Base.isequal(a::CustomParams, b::CustomParams) = isequal(a.data, b.data)
-Base.hash(params::CustomParams, h::UInt) = hash(params.data, h)
+Base.string(k::StructuredKey) = k.name
+Base.:(==)(a::StructuredKey, b::StructuredKey) = a.name == b.name
+
+struct StructuredParams{P<:Pair}
+    data::Vector{P}
+end
+Base.pairs(params::StructuredParams) = params.data
+Base.isempty(params::StructuredParams) = isempty(params.data)
 
 @testset "ParamsWithStats" begin
     @testset "Constructor from NamedTuple" begin
@@ -202,16 +207,33 @@ Base.hash(params::CustomParams, h::UInt) = hash(params.data, h)
     end
 
     @testset "Constructor from custom parameter container" begin
-        params = CustomParams((x=[1.0, 2.0], y=3.0))
+        params = StructuredParams([StructuredKey("x") => 1.0, StructuredKey("y") => 3.0])
         pws = AbstractMCMC.ParamsWithStats(params, (lp=-10.0,))
         @test pws.params === params
         @test pws.stats == (lp=-10.0,)
         @test pws.extras == NamedTuple()
-        @test collect(pairs(pws)) == [:x => [1.0, 2.0], :y => 3.0, :lp => -10.0]
+        @test collect(pairs(pws)) ==
+            [StructuredKey("x") => 1.0, StructuredKey("y") => 3.0, :lp => -10.0]
         @test !isempty(pws)
 
-        empty_pws = AbstractMCMC.ParamsWithStats(CustomParams(NamedTuple()), NamedTuple())
+        empty_pws = AbstractMCMC.ParamsWithStats(
+            StructuredParams(Pair{StructuredKey,Float64}[]), NamedTuple()
+        )
         @test isempty(empty_pws)
+    end
+
+    @testset "Mixed key types from params and stats" begin
+        params = StructuredParams([StructuredKey("μ") => 1.0])
+        pws = AbstractMCMC.ParamsWithStats(params, (lp=-10.0,), (step_size=0.1,))
+        pairs_list = collect(Base.pairs(pws))
+        @test pairs_list == [StructuredKey("μ") => 1.0, :lp => -10.0, :step_size => 0.1]
+        @test pairs_list[1][1] isa StructuredKey
+        @test pairs_list[2][1] isa Symbol
+
+        # NameFilter stringifies keys, so non-Symbol parameter keys still filter.
+        f = AbstractMCMC.NameFilter(; include=["μ", "lp"])
+        filtered = collect(Iterators.filter(((k, _),) -> f(k), pairs_list))
+        @test filtered == [StructuredKey("μ") => 1.0, :lp => -10.0]
     end
 
     @testset "Constructor from state" begin
@@ -223,6 +245,22 @@ Base.hash(params::CustomParams, h::UInt) = hash(params.data, h)
         @test pws.params == NamedTuple()  # Empty vector becomes empty NamedTuple
         @test pws.stats == (iteration=5,)
         @test pws.extras == NamedTuple()
+    end
+
+    @testset "Extraction constructor preserves custom parameter container" begin
+        struct StructuredState
+            params::StructuredParams
+        end
+        AbstractMCMC.getparams(s::StructuredState) = s.params
+        AbstractMCMC.getstats(s::StructuredState) = (lp=-3.0,)
+
+        params = StructuredParams([StructuredKey("α") => 0.5])
+        state = StructuredState(params)
+        pws = AbstractMCMC.ParamsWithStats(
+            MyModel(), MySampler(), nothing, state; params=true, stats=true
+        )
+        @test pws.params === params
+        @test collect(Base.pairs(pws)) == [StructuredKey("α") => 0.5, :lp => -3.0]
     end
 
     @testset "Copy constructor with selection" begin
@@ -238,7 +276,7 @@ Base.hash(params::CustomParams, h::UInt) = hash(params.data, h)
         @test pws_stats.params == NamedTuple()
         @test pws_stats.stats == (lp=-10.0,)
 
-        custom_params = CustomParams((x=1.0,))
+        custom_params = StructuredParams([StructuredKey("x") => 1.0])
         custom_pws = AbstractMCMC.ParamsWithStats(custom_params, NamedTuple())
         @test AbstractMCMC.ParamsWithStats(custom_pws; stats=false).params === custom_params
         @test AbstractMCMC.ParamsWithStats(custom_pws; params=false).params == NamedTuple()
@@ -261,35 +299,14 @@ Base.hash(params::CustomParams, h::UInt) = hash(params.data, h)
         @test isempty(pws_empty)
     end
 
-    @testset "Illegal states are unrepresentable" begin
-        # Statistics and extras must be NamedTuples.
+    @testset "Stats and extras are constrained" begin
+        # Statistics and extras must be NamedTuples. Params are not validated at
+        # construction (e.g. `1` still constructs; Base defines pairs/isempty for it).
         @test_throws MethodError AbstractMCMC.ParamsWithStats(1, 2, 3)
         @test_throws MethodError AbstractMCMC.ParamsWithStats("params", 2, NamedTuple())
         @test_throws MethodError AbstractMCMC.ParamsWithStats("params", NamedTuple(), 3)
-    end
-
-    @testset "Equality" begin
-        pws1 = AbstractMCMC.ParamsWithStats(
-            CustomParams((x=[1.0, NaN],)), (lp=-10.0,), (step_size=0.1,)
-        )
-        pws2 = AbstractMCMC.ParamsWithStats(
-            CustomParams((x=[1.0, NaN],)), (lp=-10.0,), (step_size=0.1,)
-        )
-        # NaN params: isequal/hash match, but `==` is false (NaN != NaN).
-        @test isequal(pws1, pws2)
-        @test hash(pws1) == hash(pws2)
-        @test !(pws1 == pws2)
-
-        # A differing field alone makes `==` false (NaN-free, so params don't confound).
-        base = AbstractMCMC.ParamsWithStats(
-            CustomParams((x=1.0,)), (lp=-10.0,), (step_size=0.1,)
-        )
-        @test base == AbstractMCMC.ParamsWithStats(
-            CustomParams((x=1.0,)), (lp=-10.0,), (step_size=0.1,)
-        )
-        @test base != AbstractMCMC.ParamsWithStats(
-            CustomParams((x=1.0,)), (lp=-10.0,), (step_size=0.2,)
-        )
+        @test AbstractMCMC.ParamsWithStats(1, NamedTuple(), NamedTuple()) isa
+            AbstractMCMC.ParamsWithStats
     end
 end
 

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -174,8 +174,8 @@ end
 Base.string(k::StructuredKey) = k.name
 Base.:(==)(a::StructuredKey, b::StructuredKey) = a.name == b.name
 
-struct StructuredParams{P<:Pair}
-    data::Vector{P}
+struct StructuredParams
+    data::Vector{Pair{StructuredKey,Float64}}
 end
 Base.pairs(params::StructuredParams) = params.data
 Base.isempty(params::StructuredParams) = isempty(params.data)
@@ -206,33 +206,32 @@ Base.isempty(params::StructuredParams) = isempty(params.data)
         @test pws.params == (μ=1.0, σ=2.0)
     end
 
-    @testset "Constructor from custom parameter container" begin
-        params = StructuredParams([StructuredKey("x") => 1.0, StructuredKey("y") => 3.0])
+    @testset "Structured parameter container" begin
+        params = StructuredParams([StructuredKey("μ") => 1.0, StructuredKey("y") => 3.0])
+
+        # The two-argument constructor stores the container as-is and defaults extras.
         pws = AbstractMCMC.ParamsWithStats(params, (lp=-10.0,))
         @test pws.params === params
         @test pws.stats == (lp=-10.0,)
         @test pws.extras == NamedTuple()
-        @test collect(pairs(pws)) ==
-            [StructuredKey("x") => 1.0, StructuredKey("y") => 3.0, :lp => -10.0]
-        @test !isempty(pws)
 
-        empty_pws = AbstractMCMC.ParamsWithStats(
-            StructuredParams(Pair{StructuredKey,Float64}[]), NamedTuple()
-        )
-        @test isempty(empty_pws)
-    end
-
-    @testset "Mixed key types from params and stats" begin
-        params = StructuredParams([StructuredKey("μ") => 1.0])
+        # pairs flattens params/stats/extras and yields mixed key types.
         pws = AbstractMCMC.ParamsWithStats(params, (lp=-10.0,), (step_size=0.1,))
         pairs_list = collect(Base.pairs(pws))
-        @test pairs_list == [StructuredKey("μ") => 1.0, :lp => -10.0, :step_size => 0.1]
+        @test pairs_list == [
+            StructuredKey("μ") => 1.0,
+            StructuredKey("y") => 3.0,
+            :lp => -10.0,
+            :step_size => 0.1,
+        ]
         @test pairs_list[1][1] isa StructuredKey
-        @test pairs_list[2][1] isa Symbol
+        @test pairs_list[3][1] isa Symbol
+        @test !isempty(pws)
+        @test isempty(AbstractMCMC.ParamsWithStats(StructuredParams([]), NamedTuple()))
 
         # NameFilter stringifies keys, so non-Symbol parameter keys still filter.
         f = AbstractMCMC.NameFilter(; include=["μ", "lp"])
-        filtered = collect(Iterators.filter(((k, _),) -> f(k), pairs_list))
+        filtered = filter(p -> f(first(p)), pairs_list)
         @test filtered == [StructuredKey("μ") => 1.0, :lp => -10.0]
     end
 
@@ -247,20 +246,21 @@ Base.isempty(params::StructuredParams) = isempty(params.data)
         @test pws.extras == NamedTuple()
     end
 
-    @testset "Extraction constructor preserves custom parameter container" begin
-        struct StructuredState
-            params::StructuredParams
-        end
-        AbstractMCMC.getparams(s::StructuredState) = s.params
-        AbstractMCMC.getstats(s::StructuredState) = (lp=-3.0,)
+    @testset "Structured container through extraction and re-selection" begin
+        # Let the container act as its own state so getparams/getstats drive extraction.
+        AbstractMCMC.getparams(params::StructuredParams) = params
+        AbstractMCMC.getstats(::StructuredParams) = (lp=-3.0,)
 
         params = StructuredParams([StructuredKey("α") => 0.5])
-        state = StructuredState(params)
         pws = AbstractMCMC.ParamsWithStats(
-            MyModel(), MySampler(), nothing, state; params=true, stats=true
+            MyModel(), MySampler(), nothing, params; params=true, stats=true
         )
         @test pws.params === params
         @test collect(Base.pairs(pws)) == [StructuredKey("α") => 0.5, :lp => -3.0]
+
+        # Re-selection preserves the container; deselecting substitutes an empty NamedTuple.
+        @test AbstractMCMC.ParamsWithStats(pws; stats=false).params === params
+        @test AbstractMCMC.ParamsWithStats(pws; params=false).params == NamedTuple()
     end
 
     @testset "Copy constructor with selection" begin
@@ -275,11 +275,6 @@ Base.isempty(params::StructuredParams) = isempty(params.data)
         pws_stats = AbstractMCMC.ParamsWithStats(pws; params=false, stats=true)
         @test pws_stats.params == NamedTuple()
         @test pws_stats.stats == (lp=-10.0,)
-
-        custom_params = StructuredParams([StructuredKey("x") => 1.0])
-        custom_pws = AbstractMCMC.ParamsWithStats(custom_params, NamedTuple())
-        @test AbstractMCMC.ParamsWithStats(custom_pws; stats=false).params === custom_params
-        @test AbstractMCMC.ParamsWithStats(custom_pws; params=false).params == NamedTuple()
     end
 
     @testset "Base.pairs iteration" begin

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -275,11 +275,21 @@ Base.hash(params::CustomParams, h::UInt) = hash(params.data, h)
         pws2 = AbstractMCMC.ParamsWithStats(
             CustomParams((x=[1.0, NaN],)), (lp=-10.0,), (step_size=0.1,)
         )
+        # NaN params: isequal/hash match, but `==` is false (NaN != NaN).
         @test isequal(pws1, pws2)
         @test hash(pws1) == hash(pws2)
         @test !(pws1 == pws2)
-        @test pws1 !=
-            AbstractMCMC.ParamsWithStats(pws1.params, pws1.stats, (step_size=0.2,))
+
+        # A differing field alone makes `==` false (NaN-free, so params don't confound).
+        base = AbstractMCMC.ParamsWithStats(
+            CustomParams((x=1.0,)), (lp=-10.0,), (step_size=0.1,)
+        )
+        @test base == AbstractMCMC.ParamsWithStats(
+            CustomParams((x=1.0,)), (lp=-10.0,), (step_size=0.1,)
+        )
+        @test base != AbstractMCMC.ParamsWithStats(
+            CustomParams((x=1.0,)), (lp=-10.0,), (step_size=0.2,)
+        )
     end
 end
 


### PR DESCRIPTION
`ParamsWithStats` required `params` to be a `NamedTuple`, so parameter containers with non-`Symbol` keys could not be stored without lossy conversion. This PR relaxes the struct to `ParamsWithStats{P,S<:NamedTuple,E<:NamedTuple}`: the parameter container can be any type implementing `pairs` and `isempty`, with keys that have a meaningful string form so name-based filtering and logging work. It also adds a two-argument constructor `ParamsWithStats(params, stats)` (empty `extras`) and documents that `pairs(pws)` may yield mixed key types, so consumers should iterate generically.

This is intended to be non-breaking: existing constructors and the `Vector{<:Real}`/`Vector{<:Pair}` normalizations are unchanged, and equality keeps the default struct behavior. Bumps the version to 5.16.0.
