### PR TITLE
Isolate initial_params/initial_state per chain in multi-chain sampling

### DIFF
--- a/src/sample.jl
+++ b/src/sample.jl
@@ -666,7 +666,9 @@ function mcmcsample(
                                 )
                             end
 
-                            # Sample a chain and save it to the vector.
+                            # Sample a chain and save it to the vector. `deepcopy` the init
+                            # per chain -- a shared init object segfaults under ForwardDiff
+                            # (Julia GC bug; workaround for #214).
                             chains[chainidx] = StatsBase.sample(
                                 _rng,
                                 _model,
@@ -676,12 +678,12 @@ function mcmcsample(
                                 initial_params=if initial_params === nothing
                                     nothing
                                 else
-                                    initial_params[chainidx]
+                                    deepcopy(initial_params[chainidx])
                                 end,
                                 initial_state=if initial_state === nothing
                                     nothing
                                 else
-                                    initial_state[chainidx]
+                                    deepcopy(initial_state[chainidx])
                                 end,
                                 chain_number=chainidx,
                                 kwargs...,
@@ -889,15 +891,16 @@ function mcmcsample(
         # Seed a new random number generator with the pre-made seed.
         Random.seed!(rng, seed)
 
-        # Sample a chain.
+        # Sample a chain. `deepcopy` the init per chain -- a shared init object
+        # segfaults under ForwardDiff (Julia GC bug; workaround for #214).
         return StatsBase.sample(
             rng,
             model,
             sampler,
             N;
             progressname=string(progressname, " (Chain ", i, " of ", nchains, ")"),
-            initial_params=initial_params,
-            initial_state=initial_state,
+            initial_params=deepcopy(initial_params),
+            initial_state=deepcopy(initial_state),
             chain_number=i,
             kwargs...,
         )


### PR DESCRIPTION
Multi-chain `mcmcsample` already deep-copies `model` and `sampler` per chain, but passed each `initial_params[i]`/`initial_state[i]` through uncopied. So a shared init object — e.g. `fill(init, nchains)`, a natural idiom — reaches every chain. With Turing + ForwardDiff this reliably segfaults (heap corruption surfaced during GC mark) within a few iterations; a distinct object per chain is clean.

This `deepcopy`s the per-chain init so each chain gets its own copy, matching the existing per-chain isolation of `model`/`sampler`. The underlying corruption is almost certainly an upstream Julia GC bug — it only occurs under ForwardDiff, is non-deterministic, and is independent of the init's values (the shared arrays are never mutated) — so this can only work around it, but per-chain isolation removes the footgun regardless of the Julia fix.

It's hard to add tests for these as it is a Julia GC bug. 

Fixes #214.
